### PR TITLE
첫 배포 후 API 에러 해결

### DIFF
--- a/src/main/java/org/certis/studyplatform/auth/presentation/dto/request/LoginRequestDto.java
+++ b/src/main/java/org/certis/studyplatform/auth/presentation/dto/request/LoginRequestDto.java
@@ -1,7 +1,6 @@
 package org.certis.studyplatform.auth.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +13,6 @@ import lombok.NoArgsConstructor;
 public  class LoginRequestDto {
 
     @NotBlank(message = "계정번호는 필수입니다")
-    @Size(min = 6, max = 20, message = "계정번호는 6자이상 - 20자이하여야 합니다")
     private String accountNumber;
 
     @NotBlank(message = "비밀번호는 필수입니다")

--- a/src/main/java/org/certis/studyplatform/exception/ExceptionStatus.java
+++ b/src/main/java/org/certis/studyplatform/exception/ExceptionStatus.java
@@ -35,7 +35,7 @@ public enum ExceptionStatus {
     AUTH_APPLICATION_PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다"),
     AUTH_REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED,"리프레시 토큰을 찾을 수 없습니다"),
     // Auth - Domain Layer
-    AUTH_DOMAIN_INVALID_ACCOUNT_NUMBER_LENGTH(HttpStatus.BAD_REQUEST, "계정번호는 6자 이상 20자 이하여야 합니다"),
+    AUTH_DOMAIN_INVALID_ACCOUNT_NUMBER_LENGTH(HttpStatus.BAD_REQUEST, "계정번호는 필수입니다"),
     AUTH_DOMAIN_DUPLICATE_ACCOUNT_NUMBER(HttpStatus.CONFLICT, "이미 존재하는 계정번호입니다"),
     AUTH_DOMAIN_WEAK_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호 정책을 만족하지 않습니다"),
     AUTH_DOMAIN_ACCOUNT_NOT_APPROVED(HttpStatus.FORBIDDEN, "승인되지 않은 계정입니다"),

--- a/src/main/java/org/certis/studyplatform/member/domain/MemberRole.java
+++ b/src/main/java/org/certis/studyplatform/member/domain/MemberRole.java
@@ -31,9 +31,9 @@ public enum MemberRole {
         return MemberRole.valueOf(normalizedRole);
     }
 
-    // 권한 등급 비교 : 자신보다 낮은 등급(높은 level 값)의 사용자의 role을 변경 가능
+    // 권한 등급 비교 : 자신보다 낮거나 같은 등급(높거나 같은 level 값)의 사용자의 role을 변경 가능
     public boolean canChangeRole(MemberRole role){
-        return role.level > this.level;
+        return role.level >= this.level;
     }
 
 

--- a/src/main/java/org/certis/studyplatform/member/domain/service/MemberDomainService.java
+++ b/src/main/java/org/certis/studyplatform/member/domain/service/MemberDomainService.java
@@ -618,10 +618,10 @@ public class MemberDomainService {
 
         for (MemberWithPenaltyVo member : expiredUpsolvers) {
             try {
-                // 벌점 1점 추가
-                Long currentPoints = member.penaltyPoints() != null ? member.penaltyPoints() : 0L;
-                Long newPoints = currentPoints + 1;
-                PenaltyPointsVo penaltyVo = PenaltyPointsVo.of(newPoints.intValue());
+                // 기존 벌점에 +1점 누적 (null 안전 처리)
+                long currentPoints = member.penaltyPoints() != null ? member.penaltyPoints() : 0L;
+                long newTotalPoints = currentPoints + 1L;
+                PenaltyPointsVo penaltyVo = PenaltyPointsVo.of((int) newTotalPoints);
 
                 // 새로운 유예기간 설정 (현재 + 2주)
                 OffsetDateTime nextGrace = now.plusWeeks(2)
@@ -636,13 +636,13 @@ public class MemberDomainService {
 
                 processedCount++;
 
-                log.debug("Domain: Penalty applied to member - memberId: {}, newPoints: {}, newGracePeriod: {}", 
-                    member.memberId().value(), newPoints, nextGrace);
+                log.debug("Domain: Penalty applied to member - memberId: {}, newTotalPoints: {}, newGracePeriod: {}",
+                        member.memberId().value(), newTotalPoints, nextGrace);
 
                 // 6점 이상 시 탈퇴 대상 로그
-                if (newPoints >= 6) {
-                    log.warn("Domain: Member reached withdrawal threshold - memberId: {}, totalPoints: {}", 
-                        member.memberId().value(), newPoints);
+                if (newTotalPoints >= 6) {
+                    log.warn("Domain: Member reached withdrawal threshold - memberId: {}, totalPoints: {}",
+                            member.memberId().value(), newTotalPoints);
                 }
 
             } catch (Exception e) {

--- a/src/main/java/org/certis/studyplatform/member/domain/vo/MajorVo.java
+++ b/src/main/java/org/certis/studyplatform/member/domain/vo/MajorVo.java
@@ -32,14 +32,9 @@ public record MajorVo(String value) {
 
         String trimmedMajor = major.trim();
 
-        if (trimmedMajor.length() < 2 || trimmedMajor.length() > 100) {
+        if (!trimmedMajor.matches("^[가-힣a-zA-Z0-9 \\-(){}<>,.&/+:;_|]+$")) {
             throw new DomainException(ExceptionStatus.MEMBER_DOMAIN_INVALID_MAJOR,
-                    "전공은 2자 이상 100자 이하여야 합니다");
-        }
-
-        if (!trimmedMajor.matches("^[가-힣a-zA-Z\\s\\-()]+$")) {
-            throw new DomainException(ExceptionStatus.MEMBER_DOMAIN_INVALID_MAJOR,
-                    "전공은 한글, 영문, 공백, 하이픈, 괄호만 포함할 수 있습니다");
+                    "전공은 허용되지 않는 문자를 포함할 수 없습니다");
         }
     }
 }

--- a/src/main/java/org/certis/studyplatform/member/domain/vo/SkillsVo.java
+++ b/src/main/java/org/certis/studyplatform/member/domain/vo/SkillsVo.java
@@ -63,7 +63,8 @@ public record SkillsVo(List<String> values) {
                         "기술 스택 항목은 50자 이하여야 합니다: " + trimmedSkill);
             }
 
-            if (!trimmedSkill.matches("^[가-힣a-zA-Z0-9\\s\\-_.#+]+$")) {
+            // 특수문자 허용 범위 확장: 한글, 영문, 숫자, 공백, 하이픈, 언더스코어, 점, 샵, 플러스, 괄호, 슬래시, 콜론, 세미콜론, 앰퍼샌드, 퍼센트, 달러, 골뱅이, 물결표, 쉼표 등
+            if (!trimmedSkill.matches("^[가-힣a-zA-Z0-9\\s\\-_.#+()/;:&%@~!?*^|\\\\,]+$")) {
                 throw new DomainException(ExceptionStatus.MEMBER_DOMAIN_INVALID_SKILLS,
                         "기술 스택 항목에 허용되지 않는 문자가 포함되어 있습니다: " + trimmedSkill);
             }

--- a/src/main/java/org/certis/studyplatform/member/infrastructure/persistence/MemberCommandRepositoryImpl.java
+++ b/src/main/java/org/certis/studyplatform/member/infrastructure/persistence/MemberCommandRepositoryImpl.java
@@ -315,7 +315,7 @@ public class MemberCommandRepositoryImpl implements MemberCommandRepository {
                 .orElseThrow(() -> new DomainException(ExceptionStatus.MEMBER_INFRASTRUCTURE_NOT_FOUND,
                         "패널티 정보를 찾을 수 없습니다: " + memberIdVo.value()));
 
-        // 점수 누적 업데이트 (정책: 없으면 예외, 있으면 +=)
+        // 점수 초기화 업데이트 (정책: 받은 값으로 초기화)
         penaltyEntity.updatePenaltyPoints(penaltyPointsVo.points());
 
         memberPenaltyJpaRepository.save(penaltyEntity);

--- a/src/main/java/org/certis/studyplatform/member/infrastructure/persistence/ProfileCommandRepositoryImpl.java
+++ b/src/main/java/org/certis/studyplatform/member/infrastructure/persistence/ProfileCommandRepositoryImpl.java
@@ -272,8 +272,8 @@ public class ProfileCommandRepositoryImpl implements ProfileCommandRepository {
         log.debug("Command Infrastructure: Uploading profile image for member ID: {}", memberIdVo.toLong());
 
         try {
-            // S3에 이미지 업로드
-            String imageUrl = s3FileService.uploadFile(file, "profile");
+            // S3에 프로필 이미지 업로드 (10MB 제한)
+            String imageUrl = s3FileService.uploadProfileImage(file, "profile", memberIdVo.toLong());
 
             // 프로필에 이미지 URL 업데이트
             memberJpaRepository.findById(memberIdVo.toLong())

--- a/src/main/java/org/certis/studyplatform/member/infrastructure/persistence/entity/MemberPenaltyEntity.java
+++ b/src/main/java/org/certis/studyplatform/member/infrastructure/persistence/entity/MemberPenaltyEntity.java
@@ -44,13 +44,13 @@ public class MemberPenaltyEntity {
     }
 
     /**
-     * 패널티 점수 갱신
+     * 패널티 점수 갱신 (초기화 방식)
      */
     public void updatePenaltyPoints(Integer points) {
-        if (points <= 0) {
-            throw new IllegalArgumentException("패널티 점수는 0보다 커야 합니다");
+        if (points < 0) {
+            throw new IllegalArgumentException("패널티 점수는 0 이상이어야 합니다");
         }
-        this.penaltyPoint += points;
+        this.penaltyPoint = points; // 덧셈에서 초기화 방식으로 변경
         this.penaltiedAt = OffsetDateTime.now();
     }
 }

--- a/src/main/java/org/certis/studyplatform/project/application/command/ProjectCommandService.java
+++ b/src/main/java/org/certis/studyplatform/project/application/command/ProjectCommandService.java
@@ -397,6 +397,7 @@ public class ProjectCommandService {
         return switch (type) {
             case PDF -> "application/pdf";
             case HWP -> "application/x-hwp";
+            case HWPX -> "application/vnd.hancom.hwpx";
             case WORD -> "application/msword";
             case PPT -> "application/vnd.ms-powerpoint";
             case PPTX -> "application/vnd.openxmlformats-officedocument.presentationml.presentation";

--- a/src/main/java/org/certis/studyplatform/project/application/mapper/ProjectApplicationDtoMapper.java
+++ b/src/main/java/org/certis/studyplatform/project/application/mapper/ProjectApplicationDtoMapper.java
@@ -274,6 +274,7 @@ public class ProjectApplicationDtoMapper {
                 .id(vo.id())
                 .memberId(vo.memberId())
                 .memberName(vo.memberName())
+                .memberGrade(vo.memberGrade())
                 .status(vo.status())
                 .createdAt(vo.createdAt())
                 .build();

--- a/src/main/java/org/certis/studyplatform/project/domain/service/ProjectParticipantDomainService.java
+++ b/src/main/java/org/certis/studyplatform/project/domain/service/ProjectParticipantDomainService.java
@@ -135,7 +135,7 @@ public class ProjectParticipantDomainService {
     }
 
     /**
-     * 프로젝트 참가 거절
+     * 프로젝트 참가 거절 (소프트 삭제)
      */
     public ProjectParticipantStatusUpdatedVo rejectParticipant(UpdateProjectParticipantStatusCommand command) {
         log.info("Domain: Rejecting participant - participantId: {}, requesterId: {}",
@@ -155,11 +155,18 @@ public class ProjectParticipantDomainService {
         // 3. 프로젝트 생성자 권한 확인
         validateProjectLeaderPermission(participant.projectId(), command.requesterId());
 
-        // 4. 거절 처리 (상태 업데이트)
-        ProjectParticipantVo updatedParticipant = participant.updateStatus(ProjectParticipantStatus.REJECTED);
-        ProjectParticipantStatusUpdatedVo result = commandRepository.updateStatus(updatedParticipant);
+        // 4. 거절 처리 (소프트 삭제)
+        commandRepository.softDeleteById(command.participantId());
 
-        log.info("Domain: Participant rejected - ID: {}", result.id());
+        // 5. 결과 VO 생성 (거절된 상태로 반환)
+        ProjectParticipantStatusUpdatedVo result = ProjectParticipantStatusUpdatedVo.of(
+                participant.id(),
+                participant.projectId(),
+                participant.memberId(),
+                participant.status(), // 이전 상태 (PENDING)
+                ProjectParticipantStatus.REJECTED); // 현재 상태 (REJECTED)
+
+        log.info("Domain: Participant rejected (soft deleted) - ID: {}", result.id());
         return result;
     }
 

--- a/src/main/java/org/certis/studyplatform/project/domain/vo/ProjectVo.java
+++ b/src/main/java/org/certis/studyplatform/project/domain/vo/ProjectVo.java
@@ -4,6 +4,7 @@ import org.certis.studyplatform.exception.DomainException;
 import org.certis.studyplatform.exception.ExceptionStatus;
 import org.certis.studyplatform.project.domain.ProjectStatus;
 import org.certis.studyplatform.shared.domain.ResultSubmitStatus;
+import org.certis.studyplatform.shared.util.DateTimeUtils;
 
 import java.time.OffsetDateTime;
 import java.util.Collections;
@@ -68,6 +69,9 @@ public record ProjectVo(
         if (startDate == null || endDate == null) {
             throw new DomainException(ExceptionStatus.PROJECT_DOMAIN_INVALID_DATE, "프로젝트 시작일과 종료일은 필수입니다");
         }
+
+        // 시작일이 월요일인지 검증
+        DateTimeUtils.validateIsMonday(startDate);
 
         // 프로젝트 종료 시에는 시작일과 종료일 비교를 건너뛰기
         // (ended_at을 현재 시간으로 설정할 때 startDate가 현재 시간보다 늦을 수 있음)

--- a/src/main/java/org/certis/studyplatform/shared/config/CorsConfig.java
+++ b/src/main/java/org/certis/studyplatform/shared/config/CorsConfig.java
@@ -1,30 +1,48 @@
 package org.certis.studyplatform.shared.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 public class CorsConfig {
+    
+    @Value("${app.cors.allowed-origins:https://cert-is.com}")
+    private String corsAllowedOrigins;
+    
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        // 로컬 개발환경 허용 (React 기본 포트)
-        configuration.setAllowedOrigins(Arrays.asList(
+        // 환경변수에서 허용된 오리진을 가져와서 파싱 (공백 제거)
+        List<String> allowedOrigins = new ArrayList<>(Arrays.asList(corsAllowedOrigins.split(","))
+                .stream()
+                .map(String::trim)
+                .toList());
+        
+        // 기본 개발환경 오리진들 추가
+        List<String> defaultOrigins = Arrays.asList(
                 "http://localhost:8080",
                 "http://localhost:3000",      // React 개발 서버
                 "http://127.0.0.1:3000",      // 동일한 주소의 다른 표현
                 "https://localhost:3000",      // HTTPS 로컬
                 "https://www.cert-is.com",
                 "https://cert-is.com",
+                "https://api.cert-is.com",    // API 서버 도메인
                 "https://cert-is.vercel.app",
                 "https://certis.mooo.com"
-        ));
+        );
+        
+        // 환경변수 오리진과 기본 오리진을 합침
+        allowedOrigins.addAll(defaultOrigins);
+        configuration.setAllowedOrigins(allowedOrigins);
 
         // 허용할 HTTP 메서드
         configuration.setAllowedMethods(Arrays.asList(
@@ -49,3 +67,4 @@ public class CorsConfig {
         return source;
     }
 }
+

--- a/src/main/java/org/certis/studyplatform/shared/config/SecurityConfig.java
+++ b/src/main/java/org/certis/studyplatform/shared/config/SecurityConfig.java
@@ -108,6 +108,8 @@ public class SecurityConfig {
                                 "/favicon.ico",
                                 "/error"
                         ).permitAll()
+                        // Admin API는 STAFF 이상 권한 필요
+                        .requestMatchers("/api/v1/admin/**").hasAnyRole("STAFF", "VICECHAIRMAN", "CHAIRMAN", "ADMIN")
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/org/certis/studyplatform/shared/service/S3AttachmentService.java
+++ b/src/main/java/org/certis/studyplatform/shared/service/S3AttachmentService.java
@@ -400,12 +400,95 @@ public class S3AttachmentService {
     }
 
     /**
+     * 프로필 이미지 전용 업로드 (10MB 제한)
+     */
+    public String uploadProfileImage(MultipartFile file, String domain, Long entityId) {
+        try {
+            // 파일 유효성 검증
+            if (file == null || file.isEmpty()) {
+                throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_INVALID_FILE_TYPE);
+            }
+
+            // 프로필 이미지 파일 크기 제한: 10MB
+            validateFileSize(file, 10);
+            
+            // 이미지 파일 타입 검증
+            validateImageFileType(file);
+            
+            // 고유한 파일명 생성
+            String originalFileName = file.getOriginalFilename();
+            String extension = originalFileName != null && originalFileName.contains(".") 
+                    ? originalFileName.substring(originalFileName.lastIndexOf("."))
+                    : "";
+            String uniqueFileName = UUID.randomUUID().toString() + extension;
+            
+            // S3 키 생성 (도메인별로 폴더 구분)
+            String s3Key = String.format("%s/%d/%s", domain, entityId, uniqueFileName);
+            
+            // S3에 실제 파일 업로드
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromBytes(file.getBytes()));
+            
+            // S3 URL 생성
+            String s3Url = String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, s3Key);
+            
+            log.info("프로필 이미지 업로드 성공: domain={}, entityId={}, s3Key={}, url={}, size={}bytes", 
+                    domain, entityId, s3Key, s3Url, file.getSize());
+            
+            return s3Url;
+
+        } catch (IOException e) {
+            log.error("프로필 이미지 읽기 중 오류 발생: domain={}, entityId={}, error={}", 
+                    domain, entityId, e.getMessage());
+            throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_UPLOAD_FAILED);
+        } catch (S3Exception e) {
+            log.error("프로필 이미지 S3 업로드 중 오류 발생: domain={}, entityId={}, error={}", 
+                    domain, entityId, e.getMessage());
+            throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_UPLOAD_FAILED);
+        } catch (Exception e) {
+            log.error("프로필 이미지 S3 업로드 중 예상치 못한 오류 발생: domain={}, entityId={}, error={}", 
+                    domain, entityId, e.getMessage());
+            throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_UPLOAD_FAILED);
+        }
+    }
+
+    /**
      * 파일 크기 제한 검증
      */
     public void validateFileSize(MultipartFile file, long maxSizeInMB) {
         long maxSizeInBytes = maxSizeInMB * 1024 * 1024;
         if (file.getSize() > maxSizeInBytes) {
             throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_FILE_TOO_LARGE);
+        }
+    }
+
+    /**
+     * 이미지 파일 타입 검증
+     */
+    public void validateImageFileType(MultipartFile file) {
+        String contentType = file.getContentType();
+        if (contentType == null) {
+            throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_INVALID_FILE_TYPE);
+        }
+
+        // 이미지 파일 타입만 허용
+        String[] allowedImageTypes = {"image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp"};
+        boolean isValidImageType = false;
+        
+        for (String allowedType : allowedImageTypes) {
+            if (contentType.equals(allowedType)) {
+                isValidImageType = true;
+                break;
+            }
+        }
+        
+        if (!isValidImageType) {
+            throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_INVALID_FILE_TYPE);
         }
     }
 

--- a/src/main/java/org/certis/studyplatform/shared/service/S3FileService.java
+++ b/src/main/java/org/certis/studyplatform/shared/service/S3FileService.java
@@ -23,6 +23,29 @@ public class S3FileService {
     private final S3AttachmentService s3AttachmentService;
 
     /**
+     * 프로필 이미지 전용 업로드 (10MB 제한)
+     * @param file 업로드할 이미지 파일
+     * @param domain 도메인 폴더명
+     * @param entityId 엔티티 ID
+     * @return S3 URL
+     */
+    public String uploadProfileImage(MultipartFile file, String domain, Long entityId) {
+        return s3AttachmentService.uploadProfileImage(file, domain, entityId);
+    }
+
+    /**
+     * 프로필 이미지 전용 업로드 (10MB 제한, 임시 entityId 사용)
+     * @param file 업로드할 이미지 파일
+     * @param domain 도메인 폴더명
+     * @return S3 URL
+     */
+    public String uploadProfileImage(MultipartFile file, String domain) {
+        // 임시 entityId로 타임스탬프 사용 (고유성 보장)
+        Long temporaryEntityId = System.currentTimeMillis();
+        return s3AttachmentService.uploadProfileImage(file, domain, temporaryEntityId);
+    }
+
+    /**
      * 파일을 S3에 업로드하고 URL 반환
      * @param file 업로드할 파일
      * @param domain 도메인 폴더명 (예: "schedule-attachments")

--- a/src/main/java/org/certis/studyplatform/shared/type/AttachedType.java
+++ b/src/main/java/org/certis/studyplatform/shared/type/AttachedType.java
@@ -4,6 +4,7 @@ public enum AttachedType {
     // 문서
     PDF,
     HWP,
+    HWPX,
     WORD,
     PPT,
     PPTX,

--- a/src/main/java/org/certis/studyplatform/shared/type/CollegeType.java
+++ b/src/main/java/org/certis/studyplatform/shared/type/CollegeType.java
@@ -1,0 +1,30 @@
+package org.certis.studyplatform.shared.type;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public enum CollegeType {
+    HUMANITIES_SOCIAL("humanities-social", "인문사회과학대학", "629-5303"),
+    NATURAL_SCIENCE("natural-science", "자연과학대학", "629-5506"),
+    BUSINESS("business", "경영대학", "629-5703"),
+    ENGINEERING("engineering", "공과대학", "629-6009"),
+    OCEAN_SCIENCE("ocean-science", "수산과학대학", "629-5803"),
+    ENVIRONMENT_OCEAN("environment-ocean", "환경·해양대학", "629-6506"),
+    INFO_CONVERGENCE("info-convergence", "정보융합대학", "629-4607"),
+    FUTURE_CONVERGENCE("future-convergence", "미래융합학부", "629-6601"),
+    GLOBAL_LIBERAL("global-liberal", "글로벌자율전공학부", "629-6650"),
+    STUDENT_AFFAIRS("student-affairs", "학부대학 자유전공학부", "629-7542");
+
+    private final String id;
+    private final String name;
+    private final String phone;
+
+    CollegeType(String id, String name, String phone) {
+        this.id = id;
+        this.name = name;
+        this.phone = phone;
+    }
+
+}

--- a/src/main/java/org/certis/studyplatform/shared/type/DepartmentType.java
+++ b/src/main/java/org/certis/studyplatform/shared/type/DepartmentType.java
@@ -1,0 +1,67 @@
+package org.certis.studyplatform.shared.type;
+
+import lombok.Getter;
+
+@Getter
+public enum DepartmentType {
+    // 인문사회과학대학
+    FREE_MAJOR_HS("free-major-hs", "인문사회과학대학 자유전공학부", CollegeType.HUMANITIES_SOCIAL, "629-5433"),
+    ENGLISH("english", "영어영문학부", CollegeType.HUMANITIES_SOCIAL, "629-5371"),
+    JAPANESE("japanese", "일어일문학부", CollegeType.HUMANITIES_SOCIAL, "629-5390"),
+    ADMINISTRATION_WELFARE("administration-welfare", "행정복지학부", CollegeType.HUMANITIES_SOCIAL, "629-5606"),
+    INTERNATIONAL_AREA("international-area", "국제지역학부", CollegeType.HUMANITIES_SOCIAL, "629-5330"),
+
+    // 자연과학대학
+    FREE_MAJOR_NS("free-major-ns", "자연과학대학 자유전공학부", CollegeType.NATURAL_SCIENCE, "629-5507"),
+
+    // 경영대학
+    FREE_MAJOR_BUS("free-major-bus", "경영대학 자유전공학부", CollegeType.BUSINESS, "629-5709"),
+    BUSINESS_ADMINISTRATION("business-administration", "경영학부", CollegeType.BUSINESS, "629-5717"),
+    INTERNATIONAL_TRADE("international-trade", "국제통상학부", CollegeType.BUSINESS, "629-5750"),
+
+    // 공과대학
+    FREE_MAJOR_ENG("free-major-eng", "공과대학 자유전공학부", CollegeType.ENGINEERING, "629-6013"),
+    SUSTAINABLE_ENGINEERING("sustainable-engineering", "지속가능공학부", CollegeType.ENGINEERING, null),
+    ELECTRICAL_ENGINEERING("electrical-engineering", "전기공학부", CollegeType.ENGINEERING, null),
+    MECHANICAL_ENGINEERING("mechanical-engineering", "기계공학부", CollegeType.ENGINEERING, null),
+    ENERGY_MARITIME_SYSTEM("energy-maritime-system", "에너지 수송시스템공학부", CollegeType.ENGINEERING, null),
+    ENGINEERING_CHEMICAL_MATERIALS("engineering-chemical-materials", "고분자·화학소재공학부", CollegeType.ENGINEERING, null),
+    NANO_CONVERGENCE_SEMICONDUCTOR_DEPT("nano-convergence-dept", "나노융합반도체공학부", CollegeType.ENGINEERING, null),
+    SYSTEM_MANAGEMENT_SAFETY("system-management-safety", "시스템경영·안전공학부", CollegeType.ENGINEERING, null),
+    CONVERGENCE_MATERIALS("convergence-materials", "융합소재공학부", CollegeType.ENGINEERING, null),
+
+    // 수산과학대학
+    FOOD_SCIENCE("food-science", "식품과학부", CollegeType.OCEAN_SCIENCE, null),
+    MARINE_PRODUCTION_SYSTEM("marine-production-system", "해양생산시스템관리학부", CollegeType.OCEAN_SCIENCE, "629-5886"),
+    FISHERIES_LIFE_SCIENCE("fisheries-life-science", "수산생명과학부", CollegeType.OCEAN_SCIENCE, null),
+    MARINE_INDUSTRY_EDUCATION("marine-industry-education", "수해양산업교육과", CollegeType.OCEAN_SCIENCE, null),
+    MARINE_ECONOMICS("marine-economics", "해양수산경영경제학부", CollegeType.OCEAN_SCIENCE, null),
+
+    // 환경대학
+    FREE_MAJOR_ENV("free-major-env", "환경·해양대학 자유전공학부", CollegeType.ENVIRONMENT_OCEAN, null),
+    EARTH_ENVIRONMENTAL_SYSTEM("earth-environmental-system", "지구환경시스템과학부", CollegeType.ENVIRONMENT_OCEAN, null),
+
+    // 정보융합대학
+    FREE_MAJOR_IC("free-major-ic", "정보융합대학 자유전공학부", CollegeType.INFO_CONVERGENCE, null),
+    DATA_INFORMATION_SCIENCE("data-information-science", "데이터정보과학부", CollegeType.INFO_CONVERGENCE, null),
+    MEDIA_COMMUNICATION("media-communication", "미디어커뮤니케이션학부", CollegeType.INFO_CONVERGENCE, null),
+    SMART_HEALTHCARE("smart-healthcare", "스마트헬스케어학부", CollegeType.INFO_CONVERGENCE, null),
+    ELECTRONICS_COMMUNICATION("electronics-communication", "전자정보통신공학부", CollegeType.INFO_CONVERGENCE, null),
+    DESIGN("design", "조형학부", CollegeType.INFO_CONVERGENCE, null),
+    COMPUTER_AI("computer-ai", "컴퓨터·인공지능공학부", CollegeType.INFO_CONVERGENCE, null),
+
+    // 미래융합학부
+    FUTURE_CONVERGENCE_DEPT("future-convergence-dept", "미래융합학부", CollegeType.FUTURE_CONVERGENCE, null);;
+    private final String id;
+    private final String name;
+    private final CollegeType college;
+    private final String phone;
+
+    DepartmentType(String id, String name, CollegeType college, String phone) {
+        this.id = id;
+        this.name = name;
+        this.college = college;
+        this.phone = phone;
+    }
+
+}

--- a/src/main/java/org/certis/studyplatform/shared/type/MajorType.java
+++ b/src/main/java/org/certis/studyplatform/shared/type/MajorType.java
@@ -1,0 +1,185 @@
+package org.certis.studyplatform.shared.type;
+
+import lombok.Getter;
+
+@Getter
+public enum MajorType {
+    // 인문사회과학대학 - 학과
+    KOREAN_LITERATURE("korean-literature", "국어국문학과", null, CollegeType.HUMANITIES_SOCIAL, "629-5405"),
+    HISTORY("history", "사학과", null, CollegeType.HUMANITIES_SOCIAL, "629-5422"),
+    ECONOMICS("economics", "경제학과", null, CollegeType.HUMANITIES_SOCIAL, "629-5312"),
+    LAW("law", "법학과", null, CollegeType.HUMANITIES_SOCIAL, "629-5435"),
+    CHINESE_STUDIES("chinese-studies", "중국학과", null, CollegeType.HUMANITIES_SOCIAL, "629-7050"),
+    POLITICAL_DIPLOMACY("political-diplomacy", "정치외교학과", null, CollegeType.HUMANITIES_SOCIAL, "629-5465"),
+    EARLY_CHILDHOOD_EDUCATION("early-childhood-education", "유아교육과", null, CollegeType.HUMANITIES_SOCIAL, "629-5490"),
+    FASHION_DESIGN("fashion-design", "패션디자인학과", null, CollegeType.HUMANITIES_SOCIAL, "629-5352"),
+    SOCIAL_DIVISION("social-division", "사회계열(경영학과, 중국학과, 정치외교학과)", null, CollegeType.HUMANITIES_SOCIAL, "629-5466"),
+
+    // 영어영문학부
+    ENGLISH_LITERATURE("english-literature", "영어영문학전공", DepartmentType.ENGLISH, CollegeType.HUMANITIES_SOCIAL, "629-5371"),
+    ENGLISH_CULTURE_INDUSTRY("english-culture-industry", "영어문화·산업전공", DepartmentType.ENGLISH, CollegeType.HUMANITIES_SOCIAL, "629-5370"),
+
+    // 일어일문학부
+    JAPANESE_LITERATURE("japanese-literature", "일본어문학전공", DepartmentType.JAPANESE, CollegeType.HUMANITIES_SOCIAL, "629-5390"),
+    JAPANESE_STUDIES("japanese-studies", "일본학전공", DepartmentType.JAPANESE, CollegeType.HUMANITIES_SOCIAL, "629-5391"),
+
+    // 행정복지학부
+    ADMINISTRATION("administration", "행정학전공", DepartmentType.ADMINISTRATION_WELFARE, CollegeType.HUMANITIES_SOCIAL, "629-5451"),
+    SOCIAL_WELFARE("social-welfare", "사회복지학전공", DepartmentType.ADMINISTRATION_WELFARE, CollegeType.HUMANITIES_SOCIAL, "629-5450"),
+
+    // 국제지역학부
+    INTERNATIONAL_STUDIES("international-studies", "국제학전공", DepartmentType.INTERNATIONAL_AREA, CollegeType.HUMANITIES_SOCIAL, "629-5332"),
+    INTERNATIONAL_DEVELOPMENT("international-development", "국제개발협력학전공", DepartmentType.INTERNATIONAL_AREA, CollegeType.HUMANITIES_SOCIAL, "629-5330"),
+
+    // 자연과학대학 - 학과
+    APPLIED_MATHEMATICS("applied-mathematics", "응용수학과", null, CollegeType.NATURAL_SCIENCE, "629-5515"),
+    PHYSICS("physics", "물리학과", null, CollegeType.NATURAL_SCIENCE, "629-5545"),
+    CHEMISTRY("chemistry", "화학과", null, CollegeType.NATURAL_SCIENCE, "629-5580"),
+    MICROBIOLOGY("microbiology", "미생물학과", null, CollegeType.NATURAL_SCIENCE, "629-5610"),
+    NURSING("nursing", "간호학과", null, CollegeType.NATURAL_SCIENCE, "629-5780"),
+    SCIENCE_COMPUTING("science-computing", "과학컴퓨팅학과", null, CollegeType.NATURAL_SCIENCE, "629-4511"),
+
+    // 경영학부
+    BUSINESS_MANAGEMENT("business-management", "경영학전공", DepartmentType.BUSINESS_ADMINISTRATION, CollegeType.BUSINESS, "629-5717"),
+    ACCOUNTING_FINANCE("accounting-finance", "회계·재무학전공", DepartmentType.BUSINESS_ADMINISTRATION, CollegeType.BUSINESS, "629-5717"),
+    TOURISM_MANAGEMENT("tourism-management", "관광경영학전공", DepartmentType.BUSINESS_ADMINISTRATION, CollegeType.BUSINESS, "629-5717"),
+    // 국제통상학부
+    INTERNATIONAL_COMMERCE("international-commerce", "국제통상학전공", DepartmentType.BUSINESS_ADMINISTRATION, CollegeType.BUSINESS, "629-5750"),
+    INTERNATIONAL_LOGISTICS("international-logistics", "국제무역물류학전공", DepartmentType.INTERNATIONAL_TRADE, CollegeType.BUSINESS, "629-5750"),
+    INTERNATIONAL_MANAGEMENT("international-management", "국제경영학전공", DepartmentType.INTERNATIONAL_TRADE, CollegeType.BUSINESS, "629-5750"),
+
+    ARCHITECTURE_ENGINEERING("architecture-engineering", "건축공학과", null, CollegeType.ENGINEERING, "629-6081"),
+
+    // 지속가능공학부
+    CIVIL_ENGINEERING("civil-engineering", "토목공학전공", DepartmentType.SUSTAINABLE_ENGINEERING, CollegeType.ENGINEERING, "629-6060"),
+    ECOLOGICAL_ENGINEERING("ecological-engineering", "생태공학전공", DepartmentType.SUSTAINABLE_ENGINEERING, CollegeType.ENGINEERING, "629-6540"),
+
+    // 전기공학부
+    ELECTRICAL_MAJOR("electrical-major", "전기공학전공", DepartmentType.ELECTRICAL_ENGINEERING, CollegeType.ENGINEERING, "629-6306"),
+    CONTROL_MEASUREMENT("control-measurement", "제어계측공학전공", DepartmentType.ELECTRICAL_ENGINEERING, CollegeType.ENGINEERING, "629-6307"),
+    DISPLAY_SEMICONDUCTOR("display-semiconductor", "디스플레이반도체공학전공", DepartmentType.ELECTRICAL_ENGINEERING, CollegeType.ENGINEERING, "629-6405"),
+
+    // 공과대학 - 학과
+    CHEMICAL_ENGINEERING("chemical-engineering", "화학공학과", null, CollegeType.ENGINEERING, "629-6420"),
+    FIRE_PROTECTION("fire-protection", "소방공학과", null, CollegeType.ENGINEERING, "629-6462"),
+
+    // 기계공학부
+    MECHANICAL_MAJOR("mechanical-major", "기계공학전공", DepartmentType.MECHANICAL_ENGINEERING, CollegeType.ENGINEERING, "629-6125"),
+    MECHANICAL_DESIGN("mechanical-design", "기계설계공학전공", DepartmentType.MECHANICAL_ENGINEERING, CollegeType.ENGINEERING, "629-6121"),
+
+    // 에너지수송시스템공학부
+    MECHANICAL_SYSTEM("mechanical-system", "기계시스템공학전공", DepartmentType.ENERGY_MARITIME_SYSTEM, CollegeType.ENGINEERING, "629-6186"),
+    HVAC_ENGINEERING("hvac-engineering", "냉동공조공학전공", DepartmentType.ENERGY_MARITIME_SYSTEM, CollegeType.ENGINEERING, "629-6172"),
+    NAVAL_ARCHITECTURE("naval-architecture", "조선해양시스템공학전공", DepartmentType.ENERGY_MARITIME_SYSTEM, CollegeType.ENGINEERING, "629-6609"),
+
+    // 고분자·화학소재공학부
+    ENERGY_CHEMICAL_MATERIALS("energy-chemical-materials", "에너지화학소재공학전공", DepartmentType.ENGINEERING_CHEMICAL_MATERIALS, CollegeType.ENGINEERING, "629-6422"),
+    POLYMER_ENGINEERING("polymer-engineering", "고분자공학전공", DepartmentType.ENGINEERING_CHEMICAL_MATERIALS, CollegeType.ENGINEERING, "629-6424"),
+
+    // 반도체공학부
+    NANO_CONVERGENCE("nano-convergence", "나노융합공학전공", DepartmentType.NANO_CONVERGENCE_SEMICONDUCTOR_DEPT, CollegeType.ENGINEERING, "629-6385"),
+    NEXT_GEN_SEMICONDUCTOR("next-gen-semiconductor", "차세대반도체공학전공", DepartmentType.NANO_CONVERGENCE_SEMICONDUCTOR_DEPT, CollegeType.ENGINEERING, "629-7890"),
+
+    // 시스템경영·안전공학부
+    INDUSTRY_BUSINESS_ENGINEERING("industry-business_engineering", "산업경영공학전공", DepartmentType.SYSTEM_MANAGEMENT_SAFETY, CollegeType.ENGINEERING, "629-6475"),
+    TECH_DATA_ENGINEERING("tech-data-engineering", "기술·데이터공학전공", DepartmentType.SYSTEM_MANAGEMENT_SAFETY, CollegeType.ENGINEERING, "629-6475"),
+    HUMAN_ENGINEERING("human-engineering", "인전공학전공", DepartmentType.SYSTEM_MANAGEMENT_SAFETY, CollegeType.ENGINEERING, "629-6460"),
+
+    // 융합소재공학부
+    METALLURGICAL("metallurgical", "금속공학전공", DepartmentType.CONVERGENCE_MATERIALS, CollegeType.ENGINEERING, "629-6336"),
+    MATERIALS_ENGINEERING("materials-engineering", "재료공학전공", DepartmentType.CONVERGENCE_MATERIALS, CollegeType.ENGINEERING, "629-6350"),
+    NEW_MATERIALS_SYSTEM("new-materials-system", "신소재시스템공학전공", DepartmentType.CONVERGENCE_MATERIALS, CollegeType.ENGINEERING, "629-6370"),
+
+    // 수산과학대학 - 학과
+    BIOTECHNOLOGY("biotechnology", "생물공학과", null, CollegeType.OCEAN_SCIENCE, "629-5861"),
+    FISHERIES_LIFE_MEDICINE("fisheries-life-medicine", "수산생명의학과", null, CollegeType.OCEAN_SCIENCE, "629-5935"),
+
+    // 식품과학부
+    FOOD_ENGINEERING("food-engineering", "식품공학전공", DepartmentType.FOOD_SCIENCE, CollegeType.OCEAN_SCIENCE, "629-5821"),
+    FOOD_NUTRITION("food-nutrition", "식품영양학전공", DepartmentType.FOOD_SCIENCE, CollegeType.OCEAN_SCIENCE, "629-5841"),
+
+    // 해양생산시스템관리학부
+    MARINE_PRODUCTION("marine-production", "해양생산학전공", DepartmentType.MARINE_PRODUCTION_SYSTEM, CollegeType.OCEAN_SCIENCE, "629-5882"),
+    MARINE_POLICE("marine-police", "해양경찰학전공", DepartmentType.MARINE_PRODUCTION_SYSTEM, CollegeType.OCEAN_SCIENCE, "629-5880"),
+
+    // 수산생명과학부
+    AQUACULTURE_APPLIED("aquaculture-applied", "양식응용생명과학전공", DepartmentType.FISHERIES_LIFE_SCIENCE, CollegeType.OCEAN_SCIENCE, "629-5909"),
+    AQUATIC_BIOLOGY("aquatic-biology", "자원생물학전공", DepartmentType.FISHERIES_LIFE_SCIENCE, CollegeType.OCEAN_SCIENCE, "629-5930"),
+
+    // 수해양산업교육과
+    AQUACULTURE_ENGINEERING("aquaculture-engineering", "양식공학전공", DepartmentType.MARINE_INDUSTRY_EDUCATION, CollegeType.OCEAN_SCIENCE, "629-5965"),
+    FISHERIES_ENGINEERING("fisheries-engineering", "어업공학전공", DepartmentType.MARINE_INDUSTRY_EDUCATION, CollegeType.OCEAN_SCIENCE, "629-5965"),
+    NAVIGATION_ENGINEERING("navigation-engineering", "항해공학전공", DepartmentType.MARINE_INDUSTRY_EDUCATION, CollegeType.OCEAN_SCIENCE, "629-5965"),
+    MARINE_ENGINEERING("marine-engineering", "기관공학전공", DepartmentType.MARINE_INDUSTRY_EDUCATION, CollegeType.OCEAN_SCIENCE, "629-5965"),
+    REFRIGERATION_ENGINEERING("refrigeration-engineering", "냉동공학전공", DepartmentType.MARINE_INDUSTRY_EDUCATION, CollegeType.OCEAN_SCIENCE, "629-5965"),
+    MARINE_FOOD_ENGINEERING("marine-food-engineering", "식품공학전공", DepartmentType.MARINE_INDUSTRY_EDUCATION, CollegeType.OCEAN_SCIENCE, "629-5965"),
+
+    // 해양수산경영경제학부
+    MARINE_MANAGEMENT("marine-management", "해양수산경영학전공", DepartmentType.MARINE_ECONOMICS, CollegeType.OCEAN_SCIENCE, "629-5950"),
+    RESOURCE_ECONOMICS("resource-economics", "자원환경경제학전공", DepartmentType.MARINE_ECONOMICS, CollegeType.OCEAN_SCIENCE, "629-5310"),
+
+    // 환경대학 - 학과
+    OCEAN_ENGINEERING("ocean-engineering", "해양공학과", null, CollegeType.ENVIRONMENT_OCEAN, "629-6592"),
+    ENERGY_RESOURCES("energy-resources", "에너지자원공학과", null, CollegeType.ENVIRONMENT_OCEAN, "629-6551"),
+
+    // 지구환경시스템과학부
+    ENVIRONMENTAL_ENGINEERING("environmental-engineering", "환경공학전공", DepartmentType.EARTH_ENVIRONMENTAL_SYSTEM, CollegeType.ENVIRONMENT_OCEAN, "629-6520"),
+    OCEANOGRAPHY("oceanography", "해양학전공", DepartmentType.EARTH_ENVIRONMENTAL_SYSTEM, CollegeType.ENVIRONMENT_OCEAN, "629-6565"),
+    ENVIRONMENTAL_GEOLOGY("environmental-geology", "환경지질과학전공", DepartmentType.EARTH_ENVIRONMENTAL_SYSTEM, CollegeType.ENVIRONMENT_OCEAN, "629-6621"),
+    ENVIRONMENTAL_ATMOSPHERE("environmental-atmosphere", "환경대기과학전공", DepartmentType.EARTH_ENVIRONMENTAL_SYSTEM, CollegeType.ENVIRONMENT_OCEAN, "629-6636"),
+    SATELLITE_INFO("satellite-info", "위성정보융합공학전공", DepartmentType.EARTH_ENVIRONMENTAL_SYSTEM, CollegeType.ENVIRONMENT_OCEAN, "629-6650"),
+
+    // 정보융합대학 - 학과
+    ARCHITECTURE("architecture", "건축학전공", null, CollegeType.INFO_CONVERGENCE, "629-6080"),
+    DIGITAL_FINANCE("digital-finance", "디지털금융학과", null, CollegeType.INFO_CONVERGENCE, "629-7884"),
+    SMART_MOBILITY("smart-mobility", "스마트모빌리티디자인학과", null, CollegeType.INFO_CONVERGENCE, "629-7989"),
+
+    // 데이터정보과학부
+    BIG_DATA_CONVERGENCE("big-data-convergence", "빅데이터융합전공", DepartmentType.DATA_INFORMATION_SCIENCE, CollegeType.INFO_CONVERGENCE, "629-4610"),
+    STATISTICS_DATA_SCIENCE("statistics-data-science", "통계·데이터사이언스전공", DepartmentType.DATA_INFORMATION_SCIENCE, CollegeType.INFO_CONVERGENCE, "629-5534"),
+
+    // 미디어커뮤니케이션학부
+    JOURNALISM("journalism", "언론정보전공", DepartmentType.MEDIA_COMMUNICATION, CollegeType.INFO_CONVERGENCE, "629-5475"),
+    HUMAN_ICT("human-ict", "휴먼ICT융합전공", DepartmentType.MEDIA_COMMUNICATION, CollegeType.INFO_CONVERGENCE, "629-4620"),
+
+    // 스마트헬스케어학부
+    BIOMEDICAL_ENGINEERING("biomedical-engineering", "의공학전공", null, CollegeType.INFO_CONVERGENCE, "629-5872"),
+    HUMAN_BIO_CONVERGENCE("human-bio-convergence", "휴먼바이오융합전공", DepartmentType.SMART_HEALTHCARE, CollegeType.INFO_CONVERGENCE, "629-4630"),
+    MARINE_SPORTS("marine-sports", "해양스포츠전공", DepartmentType.SMART_HEALTHCARE, CollegeType.INFO_CONVERGENCE, "629-5630"),
+
+    // 전자정보통신공학부
+    ELECTRONICS("electronics", "전자공학전공", DepartmentType.ELECTRONICS_COMMUNICATION, CollegeType.INFO_CONVERGENCE, "629-6206"),
+    INFORMATION_COMMUNICATION("information-communication", "정보통신공학전공", DepartmentType.ELECTRONICS_COMMUNICATION, CollegeType.INFO_CONVERGENCE, "629-6207"),
+
+    // 조형학부
+    VISUAL_DESIGN("visual-design", "시각디자인전공", DepartmentType.DESIGN, CollegeType.INFO_CONVERGENCE, "629-5350"),
+    INDUSTRIAL_DESIGN("industrial-design", "공업디자인전공", DepartmentType.DESIGN, CollegeType.INFO_CONVERGENCE, "629-5351"),
+
+    // 컴퓨터·인공지능공학부
+    COMPUTER_ENGINEERING("computer-engineering", "컴퓨터공학전공", DepartmentType.COMPUTER_AI, CollegeType.INFO_CONVERGENCE, "629-6261"),
+    ARTIFICIAL_INTELLIGENCE("artificial-intelligence", "인공지능전공", DepartmentType.COMPUTER_AI, CollegeType.INFO_CONVERGENCE, "629-6262"),
+
+    // 미래융합학부
+    LIFELONG_COUNSELING("lifelong-counseling", "평생교육상담학전공", DepartmentType.FUTURE_CONVERGENCE_DEPT, CollegeType.FUTURE_CONVERGENCE, "629-6595"),
+    POLICE_CRIME_PSYCHOLOGY("police-crime-psychology", "경찰범죄심리학전공", DepartmentType.FUTURE_CONVERGENCE_DEPT, CollegeType.FUTURE_CONVERGENCE, "629-6595"),
+    SOCIAL_WELFARE_SERVICE("social-welfare-service", "사회복지서비스학전공", DepartmentType.FUTURE_CONVERGENCE_DEPT, CollegeType.FUTURE_CONVERGENCE, "629-6595"),
+    MECHANICAL_SHIPBUILDING("mechanical-shipbuilding", "기계조선공학전공", DepartmentType.FUTURE_CONVERGENCE_DEPT, CollegeType.FUTURE_CONVERGENCE, "629-6596"),
+    ELECTRICAL_SOFTWARE("electrical-software", "전기전자SW공학전공", DepartmentType.FUTURE_CONVERGENCE_DEPT, CollegeType.FUTURE_CONVERGENCE, "629-6596"),
+
+    GLOBAL_LIBERAL("global-liberal", "글로벌자율전공학부", null,CollegeType.GLOBAL_LIBERAL,  "629-6650"),
+    STUDENT_AFFAIRS("student-affairs", "학부대학 자유전공학부", null,  CollegeType.GLOBAL_LIBERAL,"629-7542");
+
+    private final String id;
+    private final String name;
+    private final DepartmentType department;
+    private final CollegeType college;
+    private final String phone;
+
+    MajorType(String id, String name, DepartmentType department, CollegeType college, String phone) {
+        this.id = id;
+        this.name = name;
+        this.department = department;
+        this.college = college;
+        this.phone = phone;
+    }
+}

--- a/src/main/java/org/certis/studyplatform/shared/util/DateTimeUtils.java
+++ b/src/main/java/org/certis/studyplatform/shared/util/DateTimeUtils.java
@@ -152,13 +152,25 @@ public final class DateTimeUtils {
     }
 
     /**
-     * 현재 시간이 특정 날짜 이전인지 확인
+     * 주어진 날짜가 월요일인지 확인
      *
-     * @param dateTime 비교할 날짜시간
-     * @return 이전이면 true
+     * @param dateTime 확인할 날짜시간
+     * @return 월요일이면 true
      */
-    public static boolean isBefore(OffsetDateTime dateTime) {
-        return OffsetDateTime.now().isBefore(dateTime);
+    public static boolean isMonday(OffsetDateTime dateTime) {
+        return dateTime.getDayOfWeek() == DayOfWeek.MONDAY;
+    }
+
+    /**
+     * 주어진 날짜가 월요일인지 검증하고, 아니면 예외를 던짐
+     *
+     * @param dateTime 확인할 날짜시간
+     * @throws IllegalArgumentException 월요일이 아닌 경우
+     */
+    public static void validateIsMonday(OffsetDateTime dateTime) {
+        if (!isMonday(dateTime)) {
+            throw new IllegalArgumentException("시작일은 월요일이어야 합니다. 현재 요일: " + dateTime.getDayOfWeek());
+        }
     }
 
     /**

--- a/src/main/java/org/certis/studyplatform/study/application/command/StudyCommandService.java
+++ b/src/main/java/org/certis/studyplatform/study/application/command/StudyCommandService.java
@@ -125,6 +125,7 @@ public class StudyCommandService {
         return switch (type) {
             case PDF -> "application/pdf";
             case HWP -> "application/x-hwp";
+            case HWPX -> "application/vnd.hancom.hwpx";
             case WORD -> "application/msword";
             case PPT -> "application/vnd.ms-powerpoint";
             case PPTX -> "application/vnd.openxmlformats-officedocument.presentationml.presentation";

--- a/src/main/java/org/certis/studyplatform/study/domain/service/StudyDomainService.java
+++ b/src/main/java/org/certis/studyplatform/study/domain/service/StudyDomainService.java
@@ -104,6 +104,7 @@ public class StudyDomainService {
         return switch (type) {
             case PDF -> "application/pdf";
             case HWP -> "application/x-hwp";
+            case HWPX -> "application/vnd.hancom.hwpx";
             case WORD -> "application/msword";
             case PPT -> "application/vnd.ms-powerpoint";
             case PPTX -> "application/vnd.openxmlformats-officedocument.presentationml.presentation";

--- a/src/main/java/org/certis/studyplatform/study/domain/service/StudyParticipantDomainService.java
+++ b/src/main/java/org/certis/studyplatform/study/domain/service/StudyParticipantDomainService.java
@@ -158,9 +158,17 @@ public class StudyParticipantDomainService {
         // 3. 스터디 생성자 권한 확인
         validateStudyLeaderPermission(participant.studyId(), command.requesterId());
 
-        // 4. 거절 처리 (상태 업데이트)
-        StudyParticipantVo updatedParticipant = participant.updateStatus(StudyParticipantStatus.REJECTED);
-        StudyParticipantStatusUpdatedVo result = commandRepository.updateStatus(updatedParticipant, command.requesterId());
+        // 4. 거절 처리 (소프트 삭제)
+        commandRepository.softDeleteById(command.participantId());
+
+        // 5. 결과 VO 생성 (거절된 상태로 반환)
+        StudyParticipantStatusUpdatedVo result = StudyParticipantStatusUpdatedVo.of(
+                participant.id(),
+                participant.studyId(),
+                participant.memberId(),
+                participant.status(), // 이전 상태 (PENDING)
+                StudyParticipantStatus.REJECTED, // 현재 상태 (REJECTED)
+                command.requesterId());
 
         log.info("Domain: Participant rejected (soft deleted) - ID: {}", result.id());
         return result;

--- a/src/main/java/org/certis/studyplatform/study/domain/vo/StudyVo.java
+++ b/src/main/java/org/certis/studyplatform/study/domain/vo/StudyVo.java
@@ -5,6 +5,7 @@ import org.certis.studyplatform.exception.ExceptionStatus;
 import org.certis.studyplatform.member.domain.MemberGrade;
 import org.certis.studyplatform.study.domain.StudyStatus;
 import org.certis.studyplatform.shared.domain.ResultSubmitStatus;
+import org.certis.studyplatform.shared.util.DateTimeUtils;
 
 import java.time.OffsetDateTime;
 import java.util.Collections;
@@ -67,6 +68,9 @@ public record StudyVo(
         if (startDate == null || endDate == null) {
             throw new DomainException(ExceptionStatus.STUDY_DOMAIN_DATE_INVALID, "스터디 시작일과 종료일은 필수입니다");
         }
+
+        // 시작일이 월요일인지 검증
+        DateTimeUtils.validateIsMonday(startDate);
 
         // 스터디 종료 시에는 시작일과 종료일 비교를 건너뛰기
         // (ended_at을 현재 시간으로 설정할 때 startDate가 현재 시간보다 늦을 수 있음)

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -65,8 +65,11 @@ app:
     access-token-expiry: 3600000
     refresh-token-expiry: 86400000
   cors:
-    allowed-origins: ${CORS_ALLOWED_ORIGINS:https://cert-is.com}
-
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:https://www.cert-is.com,https://cert-is.com,https://api.cert-is.com}
+    allowed-methods: GET,POST,PUT,DELETE,PATCH,OPTIONS
+    allowed-headers: Content-Type,Authorization,X-Requested-With,Accept,Origin,X-CSRF-TOKEN
+    allow-credentials: true
+    max-age: 86400
 embedded:
   postgres:
     enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -212,7 +212,7 @@ app:
 
   # 파일 업로드 기본 설정
   file:
-    allowed-types: ${FILE_ALLOWED_TYPES:jpg,jpeg,png,gif,pdf,doc,docx,xls,xlsx,ppt,pptx}
+    allowed-types: ${FILE_ALLOWED_TYPES:jpg,jpeg,png,gif,pdf,doc,docx,xls,xlsx,ppt,pptx,hwp,hwpx}
 
   # 성능 모니터링 설정
   monitoring:

--- a/src/test/java/org/certis/studyplatform/integration/ParticipantRejectReapplyIntegrationTest.java
+++ b/src/test/java/org/certis/studyplatform/integration/ParticipantRejectReapplyIntegrationTest.java
@@ -1,0 +1,558 @@
+package org.certis.studyplatform.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.certis.studyplatform.config.TestEmbeddedPostgresConfig;
+import org.certis.studyplatform.config.TestWebMvcConfig;
+import org.certis.studyplatform.project.domain.ProjectParticipantStatus;
+import org.certis.studyplatform.project.presentation.dto.request.ProjectJoinRequestDto;
+import org.certis.studyplatform.project.presentation.dto.request.ProjectJoinRejectRequestDto;
+import org.certis.studyplatform.shared.security.CurrentUser;
+import org.certis.studyplatform.study.domain.StudyParticipantStatus;
+import org.certis.studyplatform.study.presentation.dto.request.StudyJoinRequestDto;
+import org.certis.studyplatform.study.presentation.dto.request.StudyJoinRejectRequestDto;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.certis.generated.jooq.Tables.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Participant Reject 후 Reapply 통합 테스트
+ * 
+ * 🎯 테스트 목표:
+ * - 참가 신청 → 거절 → 재신청 시나리오 검증
+ * - 생성자와 관리자 모두의 거절 권한 검증
+ * - 소프트 삭제 후 중복 체크 우회 검증
+ * 
+ * 🔧 테스트 시나리오:
+ * 1. 스터디 참가 신청 → 생성자 거절 → 다시 신청 (성공)
+ * 2. 프로젝트 참가 신청 → 생성자 거절 → 다시 신청 (성공)
+ * 3. 스터디 참가 신청 → 관리자 거절 → 다시 신청 (성공)
+ * 4. 프로젝트 참가 신청 → 관리자 거절 → 다시 신청 (성공)
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({TestEmbeddedPostgresConfig.class, TestWebMvcConfig.class})
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.datasource.url=jdbc:postgresql://localhost:5432/testdb",
+    "spring.datasource.username=test",
+    "spring.datasource.password=test"
+})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ParticipantRejectReapplyIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private DSLContext dsl;
+
+    // 테스트용 상수
+    private static final Long TEST_STUDY_ID = 1L;
+    private static final Long TEST_PROJECT_ID = 1L;
+    private static Long CREATOR_ID; // 스터디/프로젝트 생성자
+    private static Long PARTICIPANT_ID; // 참가 신청자
+    private static Long ADMIN_ID; // 관리자
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 데이터 초기화
+        initializeTestData();
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 테스트 데이터 정리
+        cleanupTestData();
+    }
+
+    /**
+     * 테스트 데이터 초기화
+     */
+    private void initializeTestData() {
+        // 기존 데이터 정리
+        dsl.deleteFrom(STUDY_PARTICIPANT).execute();
+        dsl.deleteFrom(PROJECT_PARTICIPANT).execute();
+        dsl.deleteFrom(STUDY).execute();
+        dsl.deleteFrom(PROJECT).execute();
+        dsl.deleteFrom(MEMBER).execute();
+
+        // 멤버 데이터 생성
+        dsl.insertInto(MEMBER)
+                .set(MEMBER.ID, 1L)
+                .set(MEMBER.NAME, "생성자")
+                .set(MEMBER.STUDENT_NUMBER, "20210001")
+                .set(MEMBER.MAJOR, "컴퓨터공학과")
+                .set(MEMBER.ROLE, "UPSOLVER")
+                .set(MEMBER.GRADE, "JUNIOR")
+                .set(MEMBER.BIRTHDAY, OffsetDateTime.now().minusYears(20))
+                .set(MEMBER.GENDER, "MALE")
+                .set(MEMBER.CREATED_AT, OffsetDateTime.now())
+                .set(MEMBER.UPDATED_AT, OffsetDateTime.now())
+                .execute();
+
+        dsl.insertInto(MEMBER)
+                .set(MEMBER.ID, 2L)
+                .set(MEMBER.NAME, "참가자")
+                .set(MEMBER.STUDENT_NUMBER, "20210002")
+                .set(MEMBER.MAJOR, "컴퓨터공학과")
+                .set(MEMBER.ROLE, "UPSOLVER")
+                .set(MEMBER.GRADE, "SOPHOMORE")
+                .set(MEMBER.BIRTHDAY, OffsetDateTime.now().minusYears(19))
+                .set(MEMBER.GENDER, "FEMALE")
+                .set(MEMBER.CREATED_AT, OffsetDateTime.now())
+                .set(MEMBER.UPDATED_AT, OffsetDateTime.now())
+                .execute();
+
+        dsl.insertInto(MEMBER)
+                .set(MEMBER.ID, 3L)
+                .set(MEMBER.NAME, "관리자")
+                .set(MEMBER.STUDENT_NUMBER, "20210003")
+                .set(MEMBER.MAJOR, "컴퓨터공학과")
+                .set(MEMBER.ROLE, "STAFF")
+                .set(MEMBER.GRADE, "SENIOR")
+                .set(MEMBER.BIRTHDAY, OffsetDateTime.now().minusYears(22))
+                .set(MEMBER.GENDER, "MALE")
+                .set(MEMBER.CREATED_AT, OffsetDateTime.now())
+                .set(MEMBER.UPDATED_AT, OffsetDateTime.now())
+                .execute();
+
+        // 상수 설정
+        CREATOR_ID = 1L;
+        PARTICIPANT_ID = 2L;
+        ADMIN_ID = 3L;
+
+        // 스터디 데이터 생성
+        dsl.insertInto(STUDY)
+                .set(STUDY.ID, TEST_STUDY_ID)
+                .set(STUDY.TITLE, "테스트 스터디")
+                .set(STUDY.DESCRIPTION, "테스트용 스터디입니다")
+                .set(STUDY.CONTENT, "테스트 내용")
+                .set(STUDY.CATEGORY, "CTF")
+                .set(STUDY.SUBCATEGORY, "포너블")
+                .set(STUDY.MEMBER_ID, CREATOR_ID)
+                .set(STUDY.MAX_PARTICIPANTS_NUMBER, 10)
+                .set(STUDY.STARTED_AT, OffsetDateTime.now().plusDays(7))
+                .set(STUDY.ENDED_AT, OffsetDateTime.now().plusDays(35))
+                .set(STUDY.CREATED_AT, OffsetDateTime.now())
+                .set(STUDY.UPDATED_AT, OffsetDateTime.now())
+                .execute();
+
+        // 프로젝트 데이터 생성
+        dsl.insertInto(PROJECT)
+                .set(PROJECT.ID, TEST_PROJECT_ID)
+                .set(PROJECT.TITLE, "테스트 프로젝트")
+                .set(PROJECT.DESCRIPTION, "테스트용 프로젝트입니다")
+                .set(PROJECT.CONTENT, "테스트 내용")
+                .set(PROJECT.CATEGORY, "웹개발")
+                .set(PROJECT.SUBCATEGORY, "풀스택")
+                .set(PROJECT.MEMBER_ID, CREATOR_ID)
+                .set(PROJECT.MAX_PARTICIPANTS_NUMBER, 5)
+                .set(PROJECT.STARTED_AT, OffsetDateTime.now().plusDays(7))
+                .set(PROJECT.ENDED_AT, OffsetDateTime.now().plusDays(35))
+                .set(PROJECT.CREATED_AT, OffsetDateTime.now())
+                .set(PROJECT.UPDATED_AT, OffsetDateTime.now())
+                .execute();
+    }
+
+    /**
+     * 테스트 데이터 정리
+     */
+    private void cleanupTestData() {
+        dsl.deleteFrom(STUDY_PARTICIPANT).execute();
+        dsl.deleteFrom(PROJECT_PARTICIPANT).execute();
+        dsl.deleteFrom(STUDY).execute();
+        dsl.deleteFrom(PROJECT).execute();
+        dsl.deleteFrom(MEMBER).execute();
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("🔄 스터디 참가 신청 → 생성자 거절 → 다시 신청 (성공)")
+    void testStudyRejectReapplyByCreator() throws Exception {
+        // Given: 참가자가 스터디 참가 신청
+        StudyJoinRequestDto joinRequest = new StudyJoinRequestDto();
+        joinRequest.setStudyId(TEST_STUDY_ID);
+
+        // 참가자로 보안 컨텍스트 설정
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        new CurrentUser(PARTICIPANT_ID, "participant", "participant@certis.org", "참가자", "UPSOLVER"), 
+                        null)
+        );
+
+        // When: 첫 번째 참가 신청
+        mockMvc.perform(post("/api/v1/study/participant/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200))
+                .andExpect(jsonPath("$.message").value("스터디 참가 신청이 성공했습니다"));
+
+        // 참가자 정보 확인
+        var participant = dsl.selectFrom(STUDY_PARTICIPANT)
+                .where(STUDY_PARTICIPANT.STUDY_ID.eq(TEST_STUDY_ID))
+                .and(STUDY_PARTICIPANT.MEMBER_ID.eq(PARTICIPANT_ID))
+                .and(STUDY_PARTICIPANT.DELETED_AT.isNull())
+                .fetchOne();
+
+        assertThat(participant).isNotNull();
+        assertThat(participant.getStatus()).isEqualTo(StudyParticipantStatus.PENDING.name());
+
+        Long participantId = participant.getId();
+
+        // 생성자로 보안 컨텍스트 변경
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        new CurrentUser(CREATOR_ID, "creator", "creator@certis.org", "생성자", "UPSOLVER"), 
+                        null)
+        );
+
+        // When: 생성자가 참가 신청 거절
+        StudyJoinRejectRequestDto rejectRequest = new StudyJoinRejectRequestDto();
+        rejectRequest.setParticipantId(participantId);
+
+        mockMvc.perform(post("/api/v1/study/participant/join/reject")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(rejectRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200))
+                .andExpect(jsonPath("$.message").value("스터디 참가가 거절되었습니다"))
+                .andExpect(jsonPath("$.data.currentStatus").value("REJECTED"));
+
+        // 거절된 참가자가 소프트 삭제되었는지 확인
+        var rejectedParticipant = dsl.selectFrom(STUDY_PARTICIPANT)
+                .where(STUDY_PARTICIPANT.ID.eq(participantId))
+                .fetchOne();
+
+        assertThat(rejectedParticipant).isNotNull();
+        assertThat(rejectedParticipant.getDeletedAt()).isNotNull(); // 소프트 삭제 확인
+
+        // 참가자로 보안 컨텍스트 다시 설정
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        new CurrentUser(PARTICIPANT_ID, "participant", "participant@certis.org", "참가자", "UPSOLVER"), 
+                        null)
+        );
+
+        // When: 다시 참가 신청 (중복 체크 우회되어야 함)
+        mockMvc.perform(post("/api/v1/study/participant/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200))
+                .andExpect(jsonPath("$.message").value("스터디 참가 신청이 성공했습니다"));
+
+        // 새로운 참가 신청이 생성되었는지 확인
+        var newParticipant = dsl.selectFrom(STUDY_PARTICIPANT)
+                .where(STUDY_PARTICIPANT.STUDY_ID.eq(TEST_STUDY_ID))
+                .and(STUDY_PARTICIPANT.MEMBER_ID.eq(PARTICIPANT_ID))
+                .and(STUDY_PARTICIPANT.DELETED_AT.isNull())
+                .fetchOne();
+
+        assertThat(newParticipant).isNotNull();
+        assertThat(newParticipant.getId()).isNotEqualTo(participantId); // 새로운 ID
+        assertThat(newParticipant.getStatus()).isEqualTo(StudyParticipantStatus.PENDING.name());
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("🔄 프로젝트 참가 신청 → 생성자 거절 → 다시 신청 (성공)")
+    void testProjectRejectReapplyByCreator() throws Exception {
+        // Given: 참가자가 프로젝트 참가 신청
+        ProjectJoinRequestDto joinRequest = new ProjectJoinRequestDto();
+        joinRequest.setProjectId(TEST_PROJECT_ID);
+
+        // 참가자로 보안 컨텍스트 설정
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        new CurrentUser(PARTICIPANT_ID, "participant", "participant@certis.org", "참가자", "UPSOLVER"), 
+                        null)
+        );
+
+        // When: 첫 번째 참가 신청
+        mockMvc.perform(post("/api/v1/project/participant/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200))
+                .andExpect(jsonPath("$.message").value("프로젝트 참가 신청이 성공했습니다"));
+
+        // 참가자 정보 확인
+        var participant = dsl.selectFrom(PROJECT_PARTICIPANT)
+                .where(PROJECT_PARTICIPANT.PROJECT_ID.eq(TEST_PROJECT_ID))
+                .and(PROJECT_PARTICIPANT.MEMBER_ID.eq(PARTICIPANT_ID))
+                .and(PROJECT_PARTICIPANT.DELETED_AT.isNull())
+                .fetchOne();
+
+        assertThat(participant).isNotNull();
+        assertThat(participant.getStatus()).isEqualTo(ProjectParticipantStatus.PENDING.name());
+
+        Long participantId = participant.getId();
+
+        // 생성자로 보안 컨텍스트 변경
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        new CurrentUser(CREATOR_ID, "creator", "creator@certis.org", "생성자", "UPSOLVER"), 
+                        null)
+        );
+
+        // When: 생성자가 참가 신청 거절
+        ProjectJoinRejectRequestDto rejectRequest = new ProjectJoinRejectRequestDto();
+        rejectRequest.setParticipantId(participantId);
+
+        mockMvc.perform(post("/api/v1/project/participant/join/reject")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(rejectRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200))
+                .andExpect(jsonPath("$.message").value("프로젝트 참가가 거절되었습니다"))
+                .andExpect(jsonPath("$.data.currentStatus").value("REJECTED"));
+
+        // 거절된 참가자가 소프트 삭제되었는지 확인
+        var rejectedParticipant = dsl.selectFrom(PROJECT_PARTICIPANT)
+                .where(PROJECT_PARTICIPANT.ID.eq(participantId))
+                .fetchOne();
+
+        assertThat(rejectedParticipant).isNotNull();
+        assertThat(rejectedParticipant.getDeletedAt()).isNotNull(); // 소프트 삭제 확인
+
+        // 참가자로 보안 컨텍스트 다시 설정
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        new CurrentUser(PARTICIPANT_ID, "participant", "participant@certis.org", "참가자", "UPSOLVER"), 
+                        null)
+        );
+
+        // When: 다시 참가 신청 (중복 체크 우회되어야 함)
+        mockMvc.perform(post("/api/v1/project/participant/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200))
+                .andExpect(jsonPath("$.message").value("프로젝트 참가 신청이 성공했습니다"));
+
+        // 새로운 참가 신청이 생성되었는지 확인
+        var newParticipant = dsl.selectFrom(PROJECT_PARTICIPANT)
+                .where(PROJECT_PARTICIPANT.PROJECT_ID.eq(TEST_PROJECT_ID))
+                .and(PROJECT_PARTICIPANT.MEMBER_ID.eq(PARTICIPANT_ID))
+                .and(PROJECT_PARTICIPANT.DELETED_AT.isNull())
+                .fetchOne();
+
+        assertThat(newParticipant).isNotNull();
+        assertThat(newParticipant.getId()).isNotEqualTo(participantId); // 새로운 ID
+        assertThat(newParticipant.getStatus()).isEqualTo(ProjectParticipantStatus.PENDING.name());
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("🔄 스터디 참가 신청 → 관리자 거절 → 다시 신청 (성공)")
+    void testStudyRejectReapplyByAdmin() throws Exception {
+        // Given: 참가자가 스터디 참가 신청
+        StudyJoinRequestDto joinRequest = new StudyJoinRequestDto();
+        joinRequest.setStudyId(TEST_STUDY_ID);
+
+        // 참가자로 보안 컨텍스트 설정
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        new CurrentUser(PARTICIPANT_ID, "participant", "participant@certis.org", "참가자", "UPSOLVER"), 
+                        null)
+        );
+
+        // When: 첫 번째 참가 신청
+        mockMvc.perform(post("/api/v1/study/participant/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200))
+                .andExpect(jsonPath("$.message").value("스터디 참가 신청이 성공했습니다"));
+
+        // 참가자 정보 확인
+        var participant = dsl.selectFrom(STUDY_PARTICIPANT)
+                .where(STUDY_PARTICIPANT.STUDY_ID.eq(TEST_STUDY_ID))
+                .and(STUDY_PARTICIPANT.MEMBER_ID.eq(PARTICIPANT_ID))
+                .and(STUDY_PARTICIPANT.DELETED_AT.isNull())
+                .fetchOne();
+
+        assertThat(participant).isNotNull();
+        assertThat(participant.getStatus()).isEqualTo(StudyParticipantStatus.PENDING.name());
+
+        Long participantId = participant.getId();
+
+        // 관리자로 보안 컨텍스트 변경
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        new CurrentUser(ADMIN_ID, "admin", "admin@certis.org", "관리자", "STAFF"), 
+                        null)
+        );
+
+        // When: 관리자가 참가 신청 거절
+        StudyJoinRejectRequestDto rejectRequest = new StudyJoinRejectRequestDto();
+        rejectRequest.setParticipantId(participantId);
+
+        mockMvc.perform(post("/api/v1/study/participant/join/reject")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(rejectRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200))
+                .andExpect(jsonPath("$.message").value("스터디 참가가 거절되었습니다"))
+                .andExpect(jsonPath("$.data.currentStatus").value("REJECTED"));
+
+        // 거절된 참가자가 소프트 삭제되었는지 확인
+        var rejectedParticipant = dsl.selectFrom(STUDY_PARTICIPANT)
+                .where(STUDY_PARTICIPANT.ID.eq(participantId))
+                .fetchOne();
+
+        assertThat(rejectedParticipant).isNotNull();
+        assertThat(rejectedParticipant.getDeletedAt()).isNotNull(); // 소프트 삭제 확인
+
+        // 참가자로 보안 컨텍스트 다시 설정
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        new CurrentUser(PARTICIPANT_ID, "participant", "participant@certis.org", "참가자", "UPSOLVER"), 
+                        null)
+        );
+
+        // When: 다시 참가 신청 (중복 체크 우회되어야 함)
+        mockMvc.perform(post("/api/v1/study/participant/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200))
+                .andExpect(jsonPath("$.message").value("스터디 참가 신청이 성공했습니다"));
+
+        // 새로운 참가 신청이 생성되었는지 확인
+        var newParticipant = dsl.selectFrom(STUDY_PARTICIPANT)
+                .where(STUDY_PARTICIPANT.STUDY_ID.eq(TEST_STUDY_ID))
+                .and(STUDY_PARTICIPANT.MEMBER_ID.eq(PARTICIPANT_ID))
+                .and(STUDY_PARTICIPANT.DELETED_AT.isNull())
+                .fetchOne();
+
+        assertThat(newParticipant).isNotNull();
+        assertThat(newParticipant.getId()).isNotEqualTo(participantId); // 새로운 ID
+        assertThat(newParticipant.getStatus()).isEqualTo(StudyParticipantStatus.PENDING.name());
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("🔄 프로젝트 참가 신청 → 관리자 거절 → 다시 신청 (성공)")
+    void testProjectRejectReapplyByAdmin() throws Exception {
+        // Given: 참가자가 프로젝트 참가 신청
+        ProjectJoinRequestDto joinRequest = new ProjectJoinRequestDto();
+        joinRequest.setProjectId(TEST_PROJECT_ID);
+
+        // 참가자로 보안 컨텍스트 설정
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        new CurrentUser(PARTICIPANT_ID, "participant", "participant@certis.org", "참가자", "UPSOLVER"), 
+                        null)
+        );
+
+        // When: 첫 번째 참가 신청
+        mockMvc.perform(post("/api/v1/project/participant/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200))
+                .andExpect(jsonPath("$.message").value("프로젝트 참가 신청이 성공했습니다"));
+
+        // 참가자 정보 확인
+        var participant = dsl.selectFrom(PROJECT_PARTICIPANT)
+                .where(PROJECT_PARTICIPANT.PROJECT_ID.eq(TEST_PROJECT_ID))
+                .and(PROJECT_PARTICIPANT.MEMBER_ID.eq(PARTICIPANT_ID))
+                .and(PROJECT_PARTICIPANT.DELETED_AT.isNull())
+                .fetchOne();
+
+        assertThat(participant).isNotNull();
+        assertThat(participant.getStatus()).isEqualTo(ProjectParticipantStatus.PENDING.name());
+
+        Long participantId = participant.getId();
+
+        // 관리자로 보안 컨텍스트 변경
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        new CurrentUser(ADMIN_ID, "admin", "admin@certis.org", "관리자", "STAFF"), 
+                        null)
+        );
+
+        // When: 관리자가 참가 신청 거절
+        ProjectJoinRejectRequestDto rejectRequest = new ProjectJoinRejectRequestDto();
+        rejectRequest.setParticipantId(participantId);
+
+        mockMvc.perform(post("/api/v1/project/participant/join/reject")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(rejectRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200))
+                .andExpect(jsonPath("$.message").value("프로젝트 참가가 거절되었습니다"))
+                .andExpect(jsonPath("$.data.currentStatus").value("REJECTED"));
+
+        // 거절된 참가자가 소프트 삭제되었는지 확인
+        var rejectedParticipant = dsl.selectFrom(PROJECT_PARTICIPANT)
+                .where(PROJECT_PARTICIPANT.ID.eq(participantId))
+                .fetchOne();
+
+        assertThat(rejectedParticipant).isNotNull();
+        assertThat(rejectedParticipant.getDeletedAt()).isNotNull(); // 소프트 삭제 확인
+
+        // 참가자로 보안 컨텍스트 다시 설정
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        new CurrentUser(PARTICIPANT_ID, "participant", "participant@certis.org", "참가자", "UPSOLVER"), 
+                        null)
+        );
+
+        // When: 다시 참가 신청 (중복 체크 우회되어야 함)
+        mockMvc.perform(post("/api/v1/project/participant/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinRequest)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200))
+                .andExpect(jsonPath("$.message").value("프로젝트 참가 신청이 성공했습니다"));
+
+        // 새로운 참가 신청이 생성되었는지 확인
+        var newParticipant = dsl.selectFrom(PROJECT_PARTICIPANT)
+                .where(PROJECT_PARTICIPANT.PROJECT_ID.eq(TEST_PROJECT_ID))
+                .and(PROJECT_PARTICIPANT.MEMBER_ID.eq(PARTICIPANT_ID))
+                .and(PROJECT_PARTICIPANT.DELETED_AT.isNull())
+                .fetchOne();
+
+        assertThat(newParticipant).isNotNull();
+        assertThat(newParticipant.getId()).isNotEqualTo(participantId); // 새로운 ID
+        assertThat(newParticipant.getStatus()).isEqualTo(ProjectParticipantStatus.PENDING.name());
+    }
+}

--- a/src/test/java/org/certis/studyplatform/integration/S3FileUploadIntegrationTest.java
+++ b/src/test/java/org/certis/studyplatform/integration/S3FileUploadIntegrationTest.java
@@ -329,6 +329,40 @@ class S3FileUploadIntegrationTest {
 
     @Test
     @Order(9)
+    @DisplayName("📝 HWPX 파일 업로드 테스트")
+    void uploadHwpxFile() throws IOException {
+        // Given: 테스트용 HWPX 파일 생성
+        byte[] hwpxData = createMockHwpxData();
+        String hwpxFileKey = String.format("test-files/%s/test-document.hwpx",
+                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")));
+
+        try {
+            // When: S3에 HWPX 파일 업로드
+            String uploadedUrl = uploadFile(hwpxData, "application/vnd.hancom.hwpx", hwpxFileKey);
+
+            // Then: 업로드 성공 확인
+            assertThat(uploadedUrl).isNotNull();
+            assertThat(uploadedUrl).contains(bucketName);
+            assertThat(uploadedUrl).contains(hwpxFileKey);
+            log.info("✅ HWPX 파일 업로드 성공: {}", uploadedUrl);
+
+            // When: 업로드된 파일의 메타데이터 확인
+            HeadObjectResponse metadata = getFileMetadata(hwpxFileKey);
+
+            // Then: 파일 크기와 타입 확인
+            assertThat(metadata.contentLength()).isEqualTo(hwpxData.length);
+            assertThat(metadata.contentType()).isEqualTo("application/vnd.hancom.hwpx");
+            log.info("✅ HWPX 파일 메타데이터 검증 성공 - 크기: {}바이트, 타입: {}",
+                    metadata.contentLength(), metadata.contentType());
+
+        } finally {
+            // HWPX 파일 정리 (필요시)
+            // deleteFileIfExists(hwpxFileKey);
+        }
+    }
+
+    @Test
+    @Order(10)
     @DisplayName("📁 다중 파일 타입 업로드 테스트")
     void uploadMultipleFileTypes() throws IOException {
         // Given: 여러 파일 타입 준비
@@ -338,48 +372,56 @@ class S3FileUploadIntegrationTest {
         byte[] zipData = createMockZipData();
         byte[] pdfData = createMockPdfData();
         byte[] hwpData = createMockHwpData();
+        byte[] hwpxData = createMockHwpxData();
 
         // 파일 키 생성
         String zipKey = String.format("multi-test/%s/archive.zip", timestamp);
         String pdfKey = String.format("multi-test/%s/document.pdf", timestamp);
         String hwpKey = String.format("multi-test/%s/document.hwp", timestamp);
+        String hwpxKey = String.format("multi-test/%s/document.hwpx", timestamp);
 
         try {
             // When: 여러 파일 타입 동시 업로드
             String zipUrl = uploadFile(zipData, "application/zip", zipKey);
             String pdfUrl = uploadFile(pdfData, "application/pdf", pdfKey);
             String hwpUrl = uploadFile(hwpData, "application/haansofthwp", hwpKey);
+            String hwpxUrl = uploadFile(hwpxData, "application/vnd.hancom.hwpx", hwpxKey);
 
             // Then: 모든 파일 업로드 성공 확인
             assertThat(zipUrl).contains(zipKey);
             assertThat(pdfUrl).contains(pdfKey);
             assertThat(hwpUrl).contains(hwpKey);
+            assertThat(hwpxUrl).contains(hwpxKey);
 
             // When: 모든 파일 존재 여부 확인
             boolean zipExists = checkFileExists(zipKey);
             boolean pdfExists = checkFileExists(pdfKey);
             boolean hwpExists = checkFileExists(hwpKey);
+            boolean hwpxExists = checkFileExists(hwpxKey);
 
             // Then: 모든 파일이 존재함을 확인
             assertThat(zipExists).isTrue();
             assertThat(pdfExists).isTrue();
             assertThat(hwpExists).isTrue();
+            assertThat(hwpxExists).isTrue();
 
             log.info("✅ 다중 파일 타입 업로드 테스트 성공");
             log.info("   ZIP: {}", zipUrl);
             log.info("   PDF: {}", pdfUrl);
             log.info("   HWP: {}", hwpUrl);
+            log.info("   HWPX: {}", hwpxUrl);
 
         } finally {
             // 테스트 파일 정리 (필요시)
             // deleteFileIfExists(zipKey);
             // deleteFileIfExists(pdfKey);
             // deleteFileIfExists(hwpKey);
+            // deleteFileIfExists(hwpxKey);
         }
     }
 
     @Test
-    @Order(10)
+    @Order(11)
     @DisplayName("📚 모든 AttachedType 유사 MIME 업로드 스모크 테스트")
     void uploadAllAttachedTypeLikeFiles() throws IOException {
         String ts = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
@@ -387,6 +429,7 @@ class S3FileUploadIntegrationTest {
         // 문서류
         assertThat(uploadFile(createMockPdfData(), "application/pdf", String.format("types/%s/doc.pdf", ts))).contains("doc.pdf");
         assertThat(uploadFile(createMockHwpData(), "application/haansofthwp", String.format("types/%s/doc.hwp", ts))).contains("doc.hwp");
+        assertThat(uploadFile(createMockHwpxData(), "application/vnd.hancom.hwpx", String.format("types/%s/doc.hwpx", ts))).contains("doc.hwpx");
         assertThat(uploadFile("hello".getBytes(StandardCharsets.UTF_8), "text/plain", String.format("types/%s/readme.txt", ts))).contains("readme.txt");
         assertThat(uploadFile("excel".getBytes(StandardCharsets.UTF_8), "application/vnd.ms-excel", String.format("types/%s/sheet.xls", ts))).contains("sheet.xls");
         assertThat(uploadFile("excelx".getBytes(StandardCharsets.UTF_8), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", String.format("types/%s/sheet.xlsx", ts))).contains("sheet.xlsx");
@@ -616,5 +659,25 @@ class S3FileUploadIntegrationTest {
         }
 
         return mockHwpData;
+    }
+
+    private byte[] createMockHwpxData() {
+        // HWPX 파일은 XML 기반의 한글 문서 형식
+        // 테스트용으로 간단한 XML 구조 생성
+        String hwpxContent = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+                                xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0"
+                                xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+                                office:version="1.2">
+                    <office:body>
+                        <office:text>
+                            <text:p>테스트 HWPX 문서입니다.</text:p>
+                        </office:text>
+                    </office:body>
+                </office:document>
+                """;
+
+        return hwpxContent.getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/org/certis/studyplatform/member/AdminMemberControllerTest.java
+++ b/src/test/java/org/certis/studyplatform/member/AdminMemberControllerTest.java
@@ -108,6 +108,32 @@ class AdminMemberControllerTest {
 
     @Test
     @Order(2)
+    @DisplayName("👑 관리자 회원 필드 수정 - 같은 등급 권한 변경 성공")
+    void updateMemberAdminFields_ChangeSameLevelRole_Success() throws Exception {
+        // Given: STAFF가 다른 STAFF의 권한을 변경하는 요청
+        AdminMemberUpdateRequestDto request = new AdminMemberUpdateRequestDto(
+                TEST_TARGET_MEMBER_ID,
+                MemberRole.STAFF, // 같은 등급의 권한으로 변경
+                MemberGrade.JUNIOR
+        );
+
+        // When: STAFF 권한으로 회원 필드 수정 API 호출
+        mockMvc.perform(post(BASE_URL + "/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200))
+                .andExpect(jsonPath("$.message").value("관리자권한으로 회원 프로필이 성공적으로 갱신되었습니다"))
+                .andExpect(jsonPath("$.data.memberId").value(TEST_TARGET_MEMBER_ID))
+                .andExpect(jsonPath("$.data.newRole").value("STAFF"));
+
+        // Then: 데이터베이스에서 실제 수정 확인
+        verifyMemberRoleUpdatedInDatabase(TEST_TARGET_MEMBER_ID, MemberRole.STAFF);
+    }
+
+    @Test
+    @Order(3)
     @DisplayName("🔍 관리자 회원 검색 - 키워드 검색 성공")
     void searchMembersForAdmin_Success() throws Exception {
         // Given: 검색할 회원이 존재함
@@ -126,7 +152,7 @@ class AdminMemberControllerTest {
     }
 
     @Test
-    @Order(3)
+    @Order(4)
     @DisplayName("⏰ 유예기간 부여 - 성공")
     void grantGracePeriod_Success() throws Exception {
         // Given: 유예기간 부여 요청이 준비됨
@@ -151,7 +177,7 @@ class AdminMemberControllerTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     @DisplayName("⚠️ 벌점 부여 - 성공")
     void assignPenalty_Success() throws Exception {
         // Given: 벌점 부여 요청이 준비됨
@@ -176,7 +202,7 @@ class AdminMemberControllerTest {
     }
 
     @Test
-    @Order(5)
+    @Order(6)
     @DisplayName("🗑️ 회원 삭제 - 성공")
     void deleteMember_Success() throws Exception {
         // Given: 삭제할 회원이 존재함

--- a/src/test/java/org/certis/studyplatform/member/domain/MemberRoleTest.java
+++ b/src/test/java/org/certis/studyplatform/member/domain/MemberRoleTest.java
@@ -108,6 +108,13 @@ class MemberRoleTest {
         }
         
         @Test
+        @DisplayName("CHAIRMAN은 같은 등급인 CHAIRMAN 역할도 변경할 수 있음")
+        void chairmanCanChangeSameRole() {
+            // Given & When & Then
+            assertThat(MemberRole.CHAIRMAN.canChangeRole(MemberRole.CHAIRMAN)).isTrue();
+        }
+        
+        @Test
         @DisplayName("CHAIRMAN은 ADMIN 역할을 변경할 수 없음")
         void chairmanCannotChangeAdmin() {
             // Given & When & Then
@@ -124,6 +131,13 @@ class MemberRoleTest {
         }
         
         @Test
+        @DisplayName("STAFF는 같은 등급인 STAFF 역할도 변경할 수 있음")
+        void staffCanChangeSameRole() {
+            // Given & When & Then
+            assertThat(MemberRole.STAFF.canChangeRole(MemberRole.STAFF)).isTrue();
+        }
+        
+        @Test
         @DisplayName("STAFF는 STAFF 이상의 역할을 변경할 수 없음")
         void staffCannotChangeHigherRoles() {
             // Given & When & Then
@@ -133,16 +147,29 @@ class MemberRoleTest {
         }
         
         @Test
-        @DisplayName("PLAYER는 NONE 역할만 변경할 수 있음 (현재 구현된 로직)")
+        @DisplayName("PLAYER는 NONE 역할만 변경할 수 있음")
         void playerCanOnlyChangeNoneRole() {
             // Given & When & Then
             assertThat(MemberRole.PLAYER.canChangeRole(MemberRole.ADMIN)).isFalse();
             assertThat(MemberRole.PLAYER.canChangeRole(MemberRole.CHAIRMAN)).isFalse();
             assertThat(MemberRole.PLAYER.canChangeRole(MemberRole.VICECHAIRMAN)).isFalse();
             assertThat(MemberRole.PLAYER.canChangeRole(MemberRole.STAFF)).isFalse();
-            assertThat(MemberRole.PLAYER.canChangeRole(MemberRole.UPSOLVER)).isFalse();
-            // NONE의 level(5) > PLAYER의 level(4)이므로 변경 가능
+            assertThat(MemberRole.PLAYER.canChangeRole(MemberRole.UPSOLVER)).isTrue(); // 같은 등급
             assertThat(MemberRole.PLAYER.canChangeRole(MemberRole.NONE)).isTrue();
+        }
+        
+        @Test
+        @DisplayName("PLAYER는 같은 등급인 PLAYER 역할도 변경할 수 있음")
+        void playerCanChangeSameRole() {
+            // Given & When & Then
+            assertThat(MemberRole.PLAYER.canChangeRole(MemberRole.PLAYER)).isTrue();
+        }
+        
+        @Test
+        @DisplayName("UPSOLVER는 같은 등급인 UPSOLVER 역할도 변경할 수 있음")
+        void upsolverCanChangeSameRole() {
+            // Given & When & Then
+            assertThat(MemberRole.UPSOLVER.canChangeRole(MemberRole.UPSOLVER)).isTrue();
         }
     }
 

--- a/src/test/java/org/certis/studyplatform/member/domain/vo/MajorVoTest.java
+++ b/src/test/java/org/certis/studyplatform/member/domain/vo/MajorVoTest.java
@@ -1,0 +1,51 @@
+package org.certis.studyplatform.member.domain.vo;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MajorVoTest {
+
+    @Test
+    @DisplayName("느슨한 허용: 포맷 {<College>,<Department>,<Major>} 허용")
+    void relaxedFormat_ShouldPass() {
+        String value = "{<Engineering>,<Electrical Engineering>,<Control & Measurement>}";
+        Assertions.assertThatCode(() -> MajorVo.of(value))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("느슨한 허용: <College>,<Department>,<Major> 형식 허용")
+    void angleBracketCommaSeparated_ShouldPass() {
+        String value = "<Engineering>,<Electrical Engineering>,<Control & Measurement>";
+        Assertions.assertThatCode(() -> MajorVo.of(value))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("느슨한 허용: 매우 긴 문자열도 허용")
+    void veryLongString_ShouldPass() {
+        String repeated = "Electrical Engineering, Control & Measurement / Advanced (VLSI)";
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 20; i++) {
+            if (i > 0) sb.append(" | ");
+            sb.append(repeated);
+        }
+        Assertions.assertThatCode(() -> MajorVo.of(sb.toString()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("금지된 제어문자 포함 시 예외")
+    void controlCharacters_ShouldFail() {
+        String withNewline = "Electrical\nEngineering";
+        Assertions.assertThatThrownBy(() -> MajorVo.of(withNewline))
+                .isInstanceOf(org.certis.studyplatform.exception.DomainException.class);
+
+        String withTab = "Electrical\tEngineering";
+        Assertions.assertThatThrownBy(() -> MajorVo.of(withTab))
+                .isInstanceOf(org.certis.studyplatform.exception.DomainException.class);
+    }
+}
+
+

--- a/src/test/java/org/certis/studyplatform/member/domain/vo/SkillsVoTest.java
+++ b/src/test/java/org/certis/studyplatform/member/domain/vo/SkillsVoTest.java
@@ -1,0 +1,155 @@
+package org.certis.studyplatform.member.domain.vo;
+
+import org.certis.studyplatform.exception.DomainException;
+import org.certis.studyplatform.exception.ExceptionStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("SkillsVo 테스트")
+class SkillsVoTest {
+
+    @Nested
+    @DisplayName("특수문자 허용 범위 확장 테스트")
+    class SpecialCharacterValidationTest {
+
+        @Test
+        @DisplayName("기본 허용 문자들이 정상적으로 처리됨")
+        void basicAllowedCharacters_ShouldPass() {
+            // Given: 기본 허용 문자들
+            List<String> skills = List.of(
+                    "Java", "Python", "JavaScript", "React", "Spring Boot",
+                    "MySQL", "PostgreSQL", "Docker", "Kubernetes", "Git"
+            );
+
+            // When & Then
+            assertThatCode(() -> SkillsVo.of(skills))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("확장된 특수문자들이 정상적으로 처리됨")
+        void extendedSpecialCharacters_ShouldPass() {
+            // Given: 확장된 특수문자들을 포함한 기술 스택 (20개 이하로 제한)
+            List<String> skills = List.of(
+                    "C++", "C#", "Node.js", "ASP.NET", "React.js",
+                    "Vue.js", "Angular 2+", "TypeScript", "HTML/CSS",
+                    "REST API", "GraphQL", "JWT", "OAuth 2.0",
+                    "AWS S3", "Google Cloud", "Azure DevOps",
+                    "Docker & Kubernetes", "CI/CD", "TDD & BDD",
+                    "Agile/Scrum"
+            );
+
+            // When & Then
+            assertThatCode(() -> SkillsVo.of(skills))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("괄호를 포함한 기술 스택이 정상적으로 처리됨")
+        void parenthesesCharacters_ShouldPass() {
+            // Given: 괄호를 포함한 기술 스택
+            List<String> skills = List.of(
+                    "React (Hooks)", "Vue.js (Composition API)",
+                    "Angular (v2+)", "Node.js (Express)",
+                    "Python (Django)", "Java (Spring Boot)"
+            );
+
+            // When & Then
+            assertThatCode(() -> SkillsVo.of(skills))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("슬래시와 콜론을 포함한 기술 스택이 정상적으로 처리됨")
+        void slashAndColonCharacters_ShouldPass() {
+            // Given: 슬래시와 콜론을 포함한 기술 스택
+            List<String> skills = List.of(
+                    "HTML/CSS", "JavaScript/TypeScript",
+                    "Frontend/Backend", "DevOps/SRE",
+                    "AWS: EC2, S3, Lambda", "Google: Cloud Run, BigQuery"
+            );
+
+            // When & Then
+            assertThatCode(() -> SkillsVo.of(skills))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("앰퍼샌드와 퍼센트를 포함한 기술 스택이 정상적으로 처리됨")
+        void ampersandAndPercentCharacters_ShouldPass() {
+            // Given: 앰퍼샌드와 퍼센트를 포함한 기술 스택
+            List<String> skills = List.of(
+                    "Design & Development", "Frontend & Backend",
+                    "100% Responsive Design", "Performance & Optimization"
+            );
+
+            // When & Then
+            assertThatCode(() -> SkillsVo.of(skills))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("물결표와 느낌표를 포함한 기술 스택이 정상적으로 처리됨")
+        void tildeAndExclamationCharacters_ShouldPass() {
+            // Given: 물결표와 느낌표를 포함한 기술 스택
+            List<String> skills = List.of(
+                    "~/.bashrc", "~/.gitconfig",
+                    "Awesome! React", "Great! Performance"
+            );
+
+            // When & Then
+            assertThatCode(() -> SkillsVo.of(skills))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("여전히 허용되지 않는 문자는 예외 발생")
+        void disallowedCharacters_ShouldThrowException() {
+            // Given: 허용되지 않는 문자들을 포함한 기술 스택
+            List<String> skills = List.of(
+                    "Java<script>", "SQL\"injection\"", "React'XSS'",
+                    "Node.js\n", "Python\t", "Docker\r"
+            );
+
+            // When & Then
+            assertThatThrownBy(() -> SkillsVo.of(skills))
+                    .isInstanceOf(DomainException.class)
+                    .hasMessageContaining("기술 스택 항목에 허용되지 않는 문자가 포함되어 있습니다");
+        }
+
+        @Test
+        @DisplayName("한글 기술 스택이 정상적으로 처리됨")
+        void koreanSkills_ShouldPass() {
+            // Given: 한글 기술 스택
+            List<String> skills = List.of(
+                    "자바", "파이썬", "자바스크립트", "리액트",
+                    "스프링 부트", "마이SQL", "도커", "쿠버네티스"
+            );
+
+            // When & Then
+            assertThatCode(() -> SkillsVo.of(skills))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("혼합 언어 기술 스택이 정상적으로 처리됨")
+        void mixedLanguageSkills_ShouldPass() {
+            // Given: 혼합 언어 기술 스택
+            List<String> skills = List.of(
+                    "Java & Spring Boot", "Python/Django",
+                    "JavaScript + React", "Node.js & Express",
+                    "MySQL + Redis", "Docker & Kubernetes",
+                    "AWS (S3, EC2)", "Google Cloud Platform"
+            );
+
+            // When & Then
+            assertThatCode(() -> SkillsVo.of(skills))
+                    .doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/org/certis/studyplatform/member/infrastructure/persistence/entity/MemberPenaltyEntityTest.java
+++ b/src/test/java/org/certis/studyplatform/member/infrastructure/persistence/entity/MemberPenaltyEntityTest.java
@@ -1,0 +1,130 @@
+package org.certis.studyplatform.member.infrastructure.persistence.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("MemberPenaltyEntity 테스트")
+class MemberPenaltyEntityTest {
+
+    @Nested
+    @DisplayName("벌점 초기화 방식 테스트")
+    class PenaltyInitializationTest {
+
+        @Test
+        @DisplayName("벌점을 초기화 방식으로 업데이트")
+        void updatePenaltyPoints_ShouldInitializeValue() {
+            // Given: 초기 벌점이 3점인 엔티티
+            MemberPenaltyEntity entity = MemberPenaltyEntity.builder()
+                    .memberId(1L)
+                    .penaltyPoint(3)
+                    .penaltiedAt(OffsetDateTime.now(ZoneOffset.UTC))
+                    .updatedAt(OffsetDateTime.now(ZoneOffset.UTC))
+                    .build();
+
+            // When: 5점으로 업데이트 (덧셈이 아닌 초기화)
+            entity.updatePenaltyPoints(5);
+
+            // Then: 벌점이 5점으로 초기화됨 (3 + 5 = 8이 아님)
+            assertThat(entity.getPenaltyPoint()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("벌점을 0점으로 초기화")
+        void updatePenaltyPoints_WithZero_ShouldInitializeToZero() {
+            // Given: 초기 벌점이 5점인 엔티티
+            MemberPenaltyEntity entity = MemberPenaltyEntity.builder()
+                    .memberId(1L)
+                    .penaltyPoint(5)
+                    .penaltiedAt(OffsetDateTime.now(ZoneOffset.UTC))
+                    .updatedAt(OffsetDateTime.now(ZoneOffset.UTC))
+                    .build();
+
+            // When: 0점으로 업데이트
+            entity.updatePenaltyPoints(0);
+
+            // Then: 벌점이 0점으로 초기화됨
+            assertThat(entity.getPenaltyPoint()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("음수 벌점은 예외 발생")
+        void updatePenaltyPoints_WithNegative_ShouldThrowException() {
+            // Given: 초기 벌점이 3점인 엔티티
+            MemberPenaltyEntity entity = MemberPenaltyEntity.builder()
+                    .memberId(1L)
+                    .penaltyPoint(3)
+                    .penaltiedAt(OffsetDateTime.now(ZoneOffset.UTC))
+                    .updatedAt(OffsetDateTime.now(ZoneOffset.UTC))
+                    .build();
+
+            // When & Then: 음수 벌점은 예외 발생
+            assertThatThrownBy(() -> entity.updatePenaltyPoints(-1))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("패널티 점수는 0 이상이어야 합니다");
+        }
+
+        @Test
+        @DisplayName("벌점 업데이트 시 penaltiedAt이 현재 시간으로 설정됨")
+        void updatePenaltyPoints_ShouldUpdatePenaltiedAt() {
+            // Given: 초기 시간이 과거인 엔티티
+            OffsetDateTime pastTime = OffsetDateTime.of(2024, 1, 1, 10, 0, 0, 0, ZoneOffset.UTC);
+            MemberPenaltyEntity entity = MemberPenaltyEntity.builder()
+                    .memberId(1L)
+                    .penaltyPoint(3)
+                    .penaltiedAt(pastTime)
+                    .updatedAt(pastTime)
+                    .build();
+
+            // When: 벌점 업데이트
+            entity.updatePenaltyPoints(5);
+
+            // Then: penaltiedAt이 현재 시간으로 업데이트됨
+            assertThat(entity.getPenaltiedAt()).isAfter(pastTime);
+        }
+
+        @Test
+        @DisplayName("여러 번 업데이트해도 항상 초기화 방식으로 동작")
+        void multipleUpdates_ShouldAlwaysInitialize() {
+            // Given: 초기 벌점이 0점인 엔티티
+            MemberPenaltyEntity entity = MemberPenaltyEntity.builder()
+                    .memberId(1L)
+                    .penaltyPoint(0)
+                    .penaltiedAt(OffsetDateTime.now(ZoneOffset.UTC))
+                    .updatedAt(OffsetDateTime.now(ZoneOffset.UTC))
+                    .build();
+
+            // When: 여러 번 업데이트
+            entity.updatePenaltyPoints(3);
+            entity.updatePenaltyPoints(7);
+            entity.updatePenaltyPoints(2);
+
+            // Then: 마지막 값인 2점으로 설정됨 (덧셈이 아님)
+            assertThat(entity.getPenaltyPoint()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("기존 덧셈 방식과의 차이점 확인")
+        void comparisonWithOldAdditionMethod() {
+            // Given: 초기 벌점이 2점인 엔티티
+            MemberPenaltyEntity entity = MemberPenaltyEntity.builder()
+                    .memberId(1L)
+                    .penaltyPoint(2)
+                    .penaltiedAt(OffsetDateTime.now(ZoneOffset.UTC))
+                    .updatedAt(OffsetDateTime.now(ZoneOffset.UTC))
+                    .build();
+
+            // When: 3점으로 업데이트
+            entity.updatePenaltyPoints(3);
+
+            // Then: 새로운 방식(초기화)에서는 3점, 기존 방식(덧셈)에서는 5점이 됨
+            assertThat(entity.getPenaltyPoint()).isEqualTo(3); // 새로운 방식
+            assertThat(entity.getPenaltyPoint()).isNotEqualTo(5); // 기존 방식과 다름
+        }
+    }
+}

--- a/src/test/java/org/certis/studyplatform/project/domain/service/ProjectParticipantDomainServiceTest.java
+++ b/src/test/java/org/certis/studyplatform/project/domain/service/ProjectParticipantDomainServiceTest.java
@@ -254,11 +254,6 @@ class ProjectParticipantDomainServiceTest {
             when(projectQueryRepository.findByIdAndDeletedAtIsNull(projectId))
                     .thenReturn(Optional.of(createProjectVo(projectId, requesterId)));
 
-            // Mock the updateStatus method to return a valid result
-            ProjectParticipantStatusUpdatedVo mockResult = new ProjectParticipantStatusUpdatedVo(
-                    participantId, projectId, 1L, ProjectParticipantStatus.PENDING, ProjectParticipantStatus.REJECTED, OffsetDateTime.now());
-            when(commandRepository.updateStatus(any())).thenReturn(mockResult);
-
             // When
             ProjectParticipantStatusUpdatedVo result = domainService.rejectParticipant(
                     createUpdateStatusCommand(participantId, requesterId));
@@ -266,8 +261,8 @@ class ProjectParticipantDomainServiceTest {
             // Then
             assertThat(result).isNotNull();
             assertThat(result.currentStatus()).isEqualTo(ProjectParticipantStatus.REJECTED);
-            verify(commandRepository).updateStatus(any());
-            verify(commandRepository, never()).softDeleteById(any());
+            verify(commandRepository).softDeleteById(participantId);
+            verify(commandRepository, never()).updateStatus(any());
         }
 
         @Test

--- a/src/test/java/org/certis/studyplatform/shared/service/S3AttachmentServiceProfileImageTest.java
+++ b/src/test/java/org/certis/studyplatform/shared/service/S3AttachmentServiceProfileImageTest.java
@@ -1,0 +1,183 @@
+package org.certis.studyplatform.shared.service;
+
+import org.certis.studyplatform.exception.InfrastructureException;
+import org.certis.studyplatform.exception.ExceptionStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("S3AttachmentService 프로필 이미지 크기 제한 테스트")
+class S3AttachmentServiceProfileImageTest {
+
+    @Nested
+    @DisplayName("프로필 이미지 크기 제한 테스트")
+    class ProfileImageSizeLimitTest {
+
+        @Test
+        @DisplayName("10MB 이하 프로필 이미지는 정상 업로드")
+        void uploadProfileImage_Under10MB_ShouldPass() {
+            // Given: 5MB 크기의 이미지 파일
+            MockMultipartFile file = createMockFile("profile.jpg", "image/jpeg", 5 * 1024 * 1024);
+
+            // When & Then: 예외가 발생하지 않아야 함
+            assertThatCode(() -> {
+                validateFileSize(file, 10);
+            }).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("10MB 초과 프로필 이미지는 예외 발생")
+        void uploadProfileImage_Over10MB_ShouldThrowException() {
+            // Given: 15MB 크기의 이미지 파일
+            MockMultipartFile file = createMockFile("large-profile.jpg", "image/jpeg", 15 * 1024 * 1024);
+
+            // When & Then: 예외가 발생해야 함
+            assertThatThrownBy(() -> {
+                validateFileSize(file, 10);
+            }).isInstanceOf(InfrastructureException.class);
+        }
+
+        @Test
+        @DisplayName("정확히 10MB 프로필 이미지는 정상 업로드")
+        void uploadProfileImage_Exactly10MB_ShouldPass() {
+            // Given: 정확히 10MB 크기의 이미지 파일
+            MockMultipartFile file = createMockFile("exact-10mb-profile.jpg", "image/jpeg", 10 * 1024 * 1024);
+
+            // When & Then: 예외가 발생하지 않아야 함
+            assertThatCode(() -> {
+                validateFileSize(file, 10);
+            }).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("10MB + 1바이트 프로필 이미지는 예외 발생")
+        void uploadProfileImage_10MBPlus1Byte_ShouldThrowException() {
+            // Given: 10MB + 1바이트 크기의 이미지 파일
+            MockMultipartFile file = createMockFile("over-10mb-profile.jpg", "image/jpeg", 10 * 1024 * 1024 + 1);
+
+            // When & Then: 예외가 발생해야 함
+            assertThatThrownBy(() -> {
+                validateFileSize(file, 10);
+            }).isInstanceOf(InfrastructureException.class);
+        }
+
+        @Test
+        @DisplayName("일반 파일 업로드는 여전히 20MB 제한")
+        void uploadRegularFile_Still20MBLimit() {
+            // Given: 15MB 크기의 일반 파일
+            MockMultipartFile file = createMockFile("document.pdf", "application/pdf", 15 * 1024 * 1024);
+
+            // When & Then: 일반 파일은 20MB 제한이므로 정상 업로드
+            assertThatCode(() -> {
+                validateFileSize(file, 20);
+            }).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("일반 파일 업로드 20MB 초과는 예외 발생")
+        void uploadRegularFile_Over20MB_ShouldThrowException() {
+            // Given: 25MB 크기의 일반 파일
+            MockMultipartFile file = createMockFile("large-document.pdf", "application/pdf", 25 * 1024 * 1024);
+
+            // When & Then: 예외가 발생해야 함
+            assertThatThrownBy(() -> {
+                validateFileSize(file, 20);
+            }).isInstanceOf(InfrastructureException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("프로필 이미지 타입 검증 테스트")
+    class ProfileImageTypeValidationTest {
+
+        @Test
+        @DisplayName("허용된 이미지 타입들은 정상 처리")
+        void allowedImageTypes_ShouldPass() {
+            String[] allowedTypes = {"image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp"};
+            
+            for (String contentType : allowedTypes) {
+                MockMultipartFile file = createMockFile("profile." + contentType.split("/")[1], contentType, 1024);
+
+                assertThatCode(() -> {
+                    validateImageFileType(file);
+                }).doesNotThrowAnyException();
+            }
+        }
+
+        @Test
+        @DisplayName("허용되지 않은 파일 타입은 예외 발생")
+        void disallowedFileTypes_ShouldThrowException() {
+            String[] disallowedTypes = {
+                    "application/pdf",
+                    "text/plain",
+                    "video/mp4",
+                    "audio/mp3",
+                    "application/zip"
+            };
+            
+            for (String contentType : disallowedTypes) {
+                MockMultipartFile file = createMockFile("file." + contentType.split("/")[1], contentType, 1024);
+
+                assertThatThrownBy(() -> {
+                    validateImageFileType(file);
+                }).isInstanceOf(InfrastructureException.class);
+            }
+        }
+
+        @Test
+        @DisplayName("null content type은 예외 발생")
+        void nullContentType_ShouldThrowException() {
+            MockMultipartFile file = new MockMultipartFile(
+                    "profileImage",
+                    "profile.jpg",
+                    null, // null content type
+                    new byte[1024]
+            );
+
+            assertThatThrownBy(() -> {
+                validateImageFileType(file);
+            }).isInstanceOf(InfrastructureException.class);
+        }
+    }
+
+    // 테스트용 헬퍼 메서드들
+    private MockMultipartFile createMockFile(String filename, String contentType, int sizeInBytes) {
+        return new MockMultipartFile(
+                "file",
+                filename,
+                contentType,
+                new byte[sizeInBytes]
+        );
+    }
+
+    private void validateFileSize(MockMultipartFile file, long maxSizeInMB) {
+        long maxSizeInBytes = maxSizeInMB * 1024 * 1024;
+        if (file.getSize() > maxSizeInBytes) {
+            throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_FILE_TOO_LARGE);
+        }
+    }
+
+    private void validateImageFileType(MockMultipartFile file) {
+        String contentType = file.getContentType();
+        if (contentType == null) {
+            throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_INVALID_FILE_TYPE);
+        }
+
+        String[] allowedImageTypes = {"image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp"};
+        boolean isValidImageType = false;
+        
+        for (String allowedType : allowedImageTypes) {
+            if (contentType.equals(allowedType)) {
+                isValidImageType = true;
+                break;
+            }
+        }
+        
+        if (!isValidImageType) {
+            throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_INVALID_FILE_TYPE);
+        }
+    }
+}

--- a/src/test/java/org/certis/studyplatform/shared/util/DateTimeUtilsTest.java
+++ b/src/test/java/org/certis/studyplatform/shared/util/DateTimeUtilsTest.java
@@ -1,0 +1,86 @@
+package org.certis.studyplatform.shared.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.DayOfWeek;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("DateTimeUtils 테스트")
+class DateTimeUtilsTest {
+
+    @Nested
+    @DisplayName("월요일 검증 테스트")
+    class MondayValidationTest {
+
+        @Test
+        @DisplayName("월요일인 경우 true 반환")
+        void isMonday_WhenMonday_ReturnsTrue() {
+            // Given: 월요일 날짜 생성
+            OffsetDateTime monday = OffsetDateTime.of(2024, 1, 1, 10, 0, 0, 0, ZoneOffset.UTC); // 2024년 1월 1일은 월요일
+
+            // When & Then
+            assertThat(DateTimeUtils.isMonday(monday)).isTrue();
+        }
+
+        @Test
+        @DisplayName("월요일이 아닌 경우 false 반환")
+        void isMonday_WhenNotMonday_ReturnsFalse() {
+            // Given: 화요일 날짜 생성
+            OffsetDateTime tuesday = OffsetDateTime.of(2024, 1, 2, 10, 0, 0, 0, ZoneOffset.UTC); // 2024년 1월 2일은 화요일
+
+            // When & Then
+            assertThat(DateTimeUtils.isMonday(tuesday)).isFalse();
+        }
+
+        @Test
+        @DisplayName("월요일인 경우 예외 발생하지 않음")
+        void validateIsMonday_WhenMonday_DoesNotThrowException() {
+            // Given: 월요일 날짜 생성
+            OffsetDateTime monday = OffsetDateTime.of(2024, 1, 1, 10, 0, 0, 0, ZoneOffset.UTC);
+
+            // When & Then
+            assertThatCode(() -> DateTimeUtils.validateIsMonday(monday))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("월요일이 아닌 경우 IllegalArgumentException 발생")
+        void validateIsMonday_WhenNotMonday_ThrowsException() {
+            // Given: 화요일 날짜 생성
+            OffsetDateTime tuesday = OffsetDateTime.of(2024, 1, 2, 10, 0, 0, 0, ZoneOffset.UTC);
+
+            // When & Then
+            assertThatThrownBy(() -> DateTimeUtils.validateIsMonday(tuesday))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("시작일은 월요일이어야 합니다")
+                    .hasMessageContaining("TUESDAY");
+        }
+
+        @Test
+        @DisplayName("다양한 요일에 대한 검증")
+        void validateIsMonday_VariousDaysOfWeek() {
+            // Given: 각 요일별 날짜 생성
+            OffsetDateTime monday = OffsetDateTime.of(2024, 1, 1, 10, 0, 0, 0, ZoneOffset.UTC);
+            OffsetDateTime tuesday = OffsetDateTime.of(2024, 1, 2, 10, 0, 0, 0, ZoneOffset.UTC);
+            OffsetDateTime wednesday = OffsetDateTime.of(2024, 1, 3, 10, 0, 0, 0, ZoneOffset.UTC);
+            OffsetDateTime thursday = OffsetDateTime.of(2024, 1, 4, 10, 0, 0, 0, ZoneOffset.UTC);
+            OffsetDateTime friday = OffsetDateTime.of(2024, 1, 5, 10, 0, 0, 0, ZoneOffset.UTC);
+            OffsetDateTime saturday = OffsetDateTime.of(2024, 1, 6, 10, 0, 0, 0, ZoneOffset.UTC);
+            OffsetDateTime sunday = OffsetDateTime.of(2024, 1, 7, 10, 0, 0, 0, ZoneOffset.UTC);
+
+            // When & Then
+            assertThat(DateTimeUtils.isMonday(monday)).isTrue();
+            assertThat(DateTimeUtils.isMonday(tuesday)).isFalse();
+            assertThat(DateTimeUtils.isMonday(wednesday)).isFalse();
+            assertThat(DateTimeUtils.isMonday(thursday)).isFalse();
+            assertThat(DateTimeUtils.isMonday(friday)).isFalse();
+            assertThat(DateTimeUtils.isMonday(saturday)).isFalse();
+            assertThat(DateTimeUtils.isMonday(sunday)).isFalse();
+        }
+    }
+}

--- a/src/test/java/org/certis/studyplatform/study/domain/service/StudyParticipantDomainServiceTest.java
+++ b/src/test/java/org/certis/studyplatform/study/domain/service/StudyParticipantDomainServiceTest.java
@@ -221,7 +221,6 @@ class StudyParticipantDomainServiceTest {
                     .thenReturn(Optional.of(createStudyVo(studyId, requesterId)));
             when(memberQueryRepository.findRoleByMemberId(new org.certis.studyplatform.member.domain.vo.MemberIdVo(requesterId)))
                     .thenReturn(Optional.of(org.certis.studyplatform.member.domain.MemberRole.PLAYER));
-            when(commandRepository.updateStatus(any(), any())).thenReturn(createStudyParticipantStatusUpdatedVo());
 
             // When
             StudyParticipantStatusUpdatedVo result = domainService.rejectParticipant(
@@ -230,7 +229,7 @@ class StudyParticipantDomainServiceTest {
             // Then
             assertThat(result).isNotNull();
             assertThat(result.currentStatus()).isEqualTo(StudyParticipantStatus.REJECTED);
-            verify(commandRepository).updateStatus(any(), any());
+            verify(commandRepository).softDeleteById(participantId);
         }
 
         @Test

--- a/src/test/java/org/certis/studyplatform/study/domain/vo/StudyVoMondayValidationTest.java
+++ b/src/test/java/org/certis/studyplatform/study/domain/vo/StudyVoMondayValidationTest.java
@@ -1,0 +1,124 @@
+package org.certis.studyplatform.study.domain.vo;
+
+import org.certis.studyplatform.exception.DomainException;
+import org.certis.studyplatform.exception.ExceptionStatus;
+import org.certis.studyplatform.member.domain.MemberGrade;
+import org.certis.studyplatform.shared.domain.ResultSubmitStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.DayOfWeek;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("StudyVo 월요일 검증 테스트")
+class StudyVoMondayValidationTest {
+
+    @Nested
+    @DisplayName("월요일 검증 테스트")
+    class MondayValidationTest {
+
+        @Test
+        @DisplayName("월요일 시작일로 스터디 생성 시 정상 처리")
+        void createStudyWithMondayStartDate_ShouldPass() {
+            // Given: 미래 월요일 시작일
+            OffsetDateTime mondayStart = OffsetDateTime.now().plusWeeks(1).with(DayOfWeek.MONDAY).withHour(10).withMinute(0).withSecond(0).withNano(0);
+            OffsetDateTime endDate = mondayStart.plusWeeks(4);
+
+            // When & Then
+            assertThatCode(() -> StudyVo.of(
+                    null, "테스트 스터디", "설명", "내용", "카테고리", "하위카테고리",
+                    mondayStart, endDate, OffsetDateTime.now(), OffsetDateTime.now(),
+                    1L, "생성자", MemberGrade.SENIOR, "2024-01", "READY",
+                    ResultSubmitStatus.READY, 5, 0, true, Collections.emptyList()
+            )).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("월요일이 아닌 시작일로 스터디 생성 시 예외 발생")
+        void createStudyWithNonMondayStartDate_ShouldThrowException() {
+            // Given: 미래 화요일 시작일
+            OffsetDateTime tuesdayStart = OffsetDateTime.now().plusWeeks(1).with(DayOfWeek.TUESDAY).withHour(10).withMinute(0).withSecond(0).withNano(0);
+            OffsetDateTime endDate = tuesdayStart.plusWeeks(4);
+
+            // When & Then
+            assertThatThrownBy(() -> StudyVo.of(
+                    null, "테스트 스터디", "설명", "내용", "카테고리", "하위카테고리",
+                    tuesdayStart, endDate, OffsetDateTime.now(), OffsetDateTime.now(),
+                    1L, "생성자", MemberGrade.SENIOR, "2024-01", "READY",
+                    ResultSubmitStatus.READY, 5, 0, true, Collections.emptyList()
+            )).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("시작일은 월요일이어야 합니다");
+        }
+
+        @Test
+        @DisplayName("다양한 요일에 대한 검증")
+        void validateVariousDaysOfWeek() {
+            // Given: 각 요일별 미래 시작일
+            OffsetDateTime monday = OffsetDateTime.now().plusWeeks(1).with(DayOfWeek.MONDAY).withHour(10).withMinute(0).withSecond(0).withNano(0);
+            OffsetDateTime tuesday = OffsetDateTime.now().plusWeeks(1).with(DayOfWeek.TUESDAY).withHour(10).withMinute(0).withSecond(0).withNano(0);
+            OffsetDateTime wednesday = OffsetDateTime.now().plusWeeks(1).with(DayOfWeek.WEDNESDAY).withHour(10).withMinute(0).withSecond(0).withNano(0);
+            OffsetDateTime thursday = OffsetDateTime.now().plusWeeks(1).with(DayOfWeek.THURSDAY).withHour(10).withMinute(0).withSecond(0).withNano(0);
+            OffsetDateTime friday = OffsetDateTime.now().plusWeeks(1).with(DayOfWeek.FRIDAY).withHour(10).withMinute(0).withSecond(0).withNano(0);
+            OffsetDateTime saturday = OffsetDateTime.now().plusWeeks(1).with(DayOfWeek.SATURDAY).withHour(10).withMinute(0).withSecond(0).withNano(0);
+            OffsetDateTime sunday = OffsetDateTime.now().plusWeeks(1).with(DayOfWeek.SUNDAY).withHour(10).withMinute(0).withSecond(0).withNano(0);
+
+            OffsetDateTime endDate = monday.plusWeeks(4);
+
+            // When & Then
+            assertThatCode(() -> StudyVo.of(
+                    null, "테스트 스터디", "설명", "내용", "카테고리", "하위카테고리",
+                    monday, endDate, OffsetDateTime.now(), OffsetDateTime.now(),
+                    1L, "생성자", MemberGrade.SENIOR, "2024-01", "READY",
+                    ResultSubmitStatus.READY, 5, 0, true, Collections.emptyList()
+            )).doesNotThrowAnyException();
+
+            // 월요일이 아닌 모든 요일은 예외 발생
+            assertThatThrownBy(() -> StudyVo.of(
+                    null, "테스트 스터디", "설명", "내용", "카테고리", "하위카테고리",
+                    tuesday, endDate, OffsetDateTime.now(), OffsetDateTime.now(),
+                    1L, "생성자", MemberGrade.SENIOR, "2024-01", "READY",
+                    ResultSubmitStatus.READY, 5, 0, true, Collections.emptyList()
+            )).isInstanceOf(IllegalArgumentException.class);
+
+            assertThatThrownBy(() -> StudyVo.of(
+                    null, "테스트 스터디", "설명", "내용", "카테고리", "하위카테고리",
+                    wednesday, endDate, OffsetDateTime.now(), OffsetDateTime.now(),
+                    1L, "생성자", MemberGrade.SENIOR, "2024-01", "READY",
+                    ResultSubmitStatus.READY, 5, 0, true, Collections.emptyList()
+            )).isInstanceOf(IllegalArgumentException.class);
+
+            assertThatThrownBy(() -> StudyVo.of(
+                    null, "테스트 스터디", "설명", "내용", "카테고리", "하위카테고리",
+                    thursday, endDate, OffsetDateTime.now(), OffsetDateTime.now(),
+                    1L, "생성자", MemberGrade.SENIOR, "2024-01", "READY",
+                    ResultSubmitStatus.READY, 5, 0, true, Collections.emptyList()
+            )).isInstanceOf(IllegalArgumentException.class);
+
+            assertThatThrownBy(() -> StudyVo.of(
+                    null, "테스트 스터디", "설명", "내용", "카테고리", "하위카테고리",
+                    friday, endDate, OffsetDateTime.now(), OffsetDateTime.now(),
+                    1L, "생성자", MemberGrade.SENIOR, "2024-01", "READY",
+                    ResultSubmitStatus.READY, 5, 0, true, Collections.emptyList()
+            )).isInstanceOf(IllegalArgumentException.class);
+
+            assertThatThrownBy(() -> StudyVo.of(
+                    null, "테스트 스터디", "설명", "내용", "카테고리", "하위카테고리",
+                    saturday, endDate, OffsetDateTime.now(), OffsetDateTime.now(),
+                    1L, "생성자", MemberGrade.SENIOR, "2024-01", "READY",
+                    ResultSubmitStatus.READY, 5, 0, true, Collections.emptyList()
+            )).isInstanceOf(IllegalArgumentException.class);
+
+            assertThatThrownBy(() -> StudyVo.of(
+                    null, "테스트 스터디", "설명", "내용", "카테고리", "하위카테고리",
+                    sunday, endDate, OffsetDateTime.now(), OffsetDateTime.now(),
+                    1L, "생성자", MemberGrade.SENIOR, "2024-01", "READY",
+                    ResultSubmitStatus.READY, 5, 0, true, Collections.emptyList()
+            )).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #이슈번호
#81 

## 📝작업 내용

### Study 관련
- 참가 요청 거절 후 재신청 시 "기참가자" 에러 발생 문제 수정
  - 거절된 참가자의 상태를 올바르게 처리하도록 로직 개선
- 생성 시 매주 월요일만 선택 가능하도록 변경
  - 날짜 선택 옵션을 매주 월요일로 제한

### Project 관련
- 참가 요청 거절 후 재신청 시 "기참가자" 에러 발생 문제 수정
  - 거절된 참가자의 상태를 올바르게 처리하도록 로직 개선
- /participant 관련 API 응답값에서 memberGrade 필드가 null인 문제 수정
  - memberGrade 필드가 정상적으로 반환되도록 수정
- 생성 시 매주 월요일만 선택 가능하도록 변경
  - 날짜 선택 옵션을 매주 월요일로 제한

### Members 관련
- 관리자페이지에서 타 사용자 Role 설정 안되는 문제 수정
  - Role 변경 권한 및 로직 수정
- 특수 문자 가능 범위 확장
  - 사용자 입력 시 허용 가능한 특수 문자 범위 확대
- 벌점 부여 시 누적(+)이 아닌 받은 인자로 초기화되도록 변경
  - 벌점 부여 로직을 누적 방식에서 설정 방식으로 변경
- 전공 저장 방식 변경에 따른 특수 기호 문제 해결
  - 전공명 저장 시 특수 기호 처리 개선

### Auth 관련
- login Request Dto에서 accountNumber 길이 제한 문제 수정
  - accountNumber 유효성 검증 로직 개선

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)