### PR TITLE
Jackson 용량 제한 및 Board 작성 제한 변경

### DIFF
--- a/src/main/java/org/certis/studyplatform/auth/application/service/AuthCommandService.java
+++ b/src/main/java/org/certis/studyplatform/auth/application/service/AuthCommandService.java
@@ -61,7 +61,6 @@ public class AuthCommandService {
 
     // accessToken 갱신
     public AccessTokenVo refreshAccessToken(RefreshTokenCommand refreshTokenCommand) {
-
         // 새 AccessToken 생성
         AccessTokenVo newAccessToken = jwtTokenProvider.generateAccessToken(
                 refreshTokenCommand.memberId(),

--- a/src/main/java/org/certis/studyplatform/auth/application/service/AuthFacadeService.java
+++ b/src/main/java/org/certis/studyplatform/auth/application/service/AuthFacadeService.java
@@ -114,12 +114,8 @@ public class AuthFacadeService {
                 memberInfo.role()
         );
 
-        // 4. 새 AccessToken 및 RefreshToken 생성
+        // 4. 새 AccessToken 생성 (RefreshToken 로테이션 없음)
         AccessTokenVo newAccessToken = authCommandService.refreshAccessToken(command);
-
-        // 5. 새로운 RefreshToken 조회 (토큰 로테이션으로 인해 새로 생성됨)
-        ValidateRefreshTokenQuery newTokenQuery = ValidateRefreshTokenQuery.of(verifiedMemberId);
-        RefreshTokenVo newRefreshToken = authQueryService.validateRefreshToken(newTokenQuery);
 
         log.info("안전한 토큰 갱신 완료: memberId={}, role={}", memberInfo.memberId(), memberInfo.role());
         return new RefreshAccessTokenResponseDto(newAccessToken.value());

--- a/src/main/java/org/certis/studyplatform/auth/presentation/dto/response/RefreshAccessTokenResponseDto.java
+++ b/src/main/java/org/certis/studyplatform/auth/presentation/dto/response/RefreshAccessTokenResponseDto.java
@@ -7,8 +7,11 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 public class RefreshAccessTokenResponseDto {
     @NotBlank(message = "액세스 토큰은 필수입니다")
     private String accessToken;
+
+    public RefreshAccessTokenResponseDto(String accessToken) {
+        this.accessToken = accessToken;
+    }
 }

--- a/src/main/java/org/certis/studyplatform/board/presentation/BoardController.java
+++ b/src/main/java/org/certis/studyplatform/board/presentation/BoardController.java
@@ -48,7 +48,6 @@ public class BoardController {
 
     // 게시글 생성
     @PostMapping("/create")
-    @PreAuthorize("hasRole('UPSOLVER') or hasRole('STAFF') or hasRole('VICECHAIRMAN') or hasRole('CHAIRMAN') or hasRole('ADMIN')") // 게시글 생성은 UPSOLVER 이상
     public ResponseEntity<GlobalResponseHandler<Void>> createBoard(
             @Valid @RequestBody BoardCreateRequestDto request,
             @AuthenticationPrincipal CurrentUser currentUser
@@ -60,7 +59,6 @@ public class BoardController {
 
     // 게시글 수정
     @PutMapping("/edit/{id}")
-    @PreAuthorize("hasRole('UPSOLVER') or hasRole('STAFF') or hasRole('VICECHAIRMAN') or hasRole('CHAIRMAN') or hasRole('ADMIN')") // 게시글 수정은 UPSOLVER 이상
     public ResponseEntity<GlobalResponseHandler<Void>> updateBoard(
             @PathVariable Long id,
             @Valid @RequestBody BoardUpdateRequestDto request,
@@ -74,7 +72,6 @@ public class BoardController {
 
     // 게시글 삭제
     @DeleteMapping("/delete/{id}")
-    @PreAuthorize("hasRole('STAFF') or hasRole('VICECHAIRMAN') or hasRole('CHAIRMAN') or hasRole('ADMIN')") // 게시글 삭제는 STAFF 이상 부터
     public ResponseEntity<GlobalResponseHandler<Void>> deleteBoard(
             @PathVariable Long id,
             @AuthenticationPrincipal CurrentUser currentUser

--- a/src/main/java/org/certis/studyplatform/shared/config/JacksonConfiguration.java
+++ b/src/main/java/org/certis/studyplatform/shared/config/JacksonConfiguration.java
@@ -1,6 +1,7 @@
 package org.certis.studyplatform.shared.config;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -38,6 +39,13 @@ public class JacksonConfiguration {
 
         // null 값 무시 (Map values에서 null 제외)
         mapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
+
+        // 대용량 파일 업로드를 위한 문자열 길이 제한 완화
+        mapper.getFactory().setStreamReadConstraints(
+            StreamReadConstraints.builder()
+                .maxStringLength(100_000_000) // 100MB로 설정
+                .build()
+        );
 
         return mapper;
     }

--- a/src/test/java/org/certis/studyplatform/auth/application/service/AuthCommandServiceTest.java
+++ b/src/test/java/org/certis/studyplatform/auth/application/service/AuthCommandServiceTest.java
@@ -80,8 +80,6 @@ class AuthCommandServiceTest {
         when(jwtTokenProvider.generateAccessToken(
                 TEST_MEMBER_ID, TEST_STUDENT_NUMBER, TEST_EMAIL, TEST_NAME, TEST_ROLE))
                 .thenReturn(mockAccessToken);
-        when(jwtTokenProvider.generateRefreshToken(TEST_MEMBER_ID))
-                .thenReturn(mockRefreshToken);
 
         // When
         AccessTokenVo result = authCommandService.refreshAccessToken(mockCommand);
@@ -94,10 +92,8 @@ class AuthCommandServiceTest {
         // 토큰 생성 검증
         verify(jwtTokenProvider, times(1)).generateAccessToken(
                 TEST_MEMBER_ID, TEST_STUDENT_NUMBER, TEST_EMAIL, TEST_NAME, TEST_ROLE);
-        verify(jwtTokenProvider, times(1)).generateRefreshToken(TEST_MEMBER_ID);
-
-        // 토큰 로테이션 검증: 새로운 RefreshToken이 Redis에 저장되었는지 확인
-        verify(authDomainService, times(1)).saveRefreshToken(mockRefreshToken);
+        verify(jwtTokenProvider, never()).generateRefreshToken(any());
+        verify(authDomainService, never()).saveRefreshToken(any());
     }
 
     @Test
@@ -125,19 +121,15 @@ class AuthCommandServiceTest {
         when(jwtTokenProvider.generateAccessToken(
                 TEST_MEMBER_ID, TEST_STUDENT_NUMBER, TEST_EMAIL, TEST_NAME, TEST_ROLE))
                 .thenReturn(mockAccessToken);
-        when(jwtTokenProvider.generateRefreshToken(TEST_MEMBER_ID))
-                .thenReturn(mockRefreshToken);
-        doThrow(new RuntimeException("Redis 저장 실패"))
-                .when(authDomainService).saveRefreshToken(any(RefreshTokenVo.class));
+        
+        // When
+        AccessTokenVo result = authCommandService.refreshAccessToken(mockCommand);
 
-        // When & Then
-        assertThatThrownBy(() -> authCommandService.refreshAccessToken(mockCommand))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("Redis 저장 실패");
-
-        // AccessToken은 생성되었지만 RefreshToken 저장이 실패했는지 확인
+        // Then: RefreshToken 저장 로직이 호출되지 않음을 검증 (현재 비즈니스 로직 상 로테이션 없음)
+        assertThat(result).isNotNull();
         verify(jwtTokenProvider, times(1)).generateAccessToken(
                 TEST_MEMBER_ID, TEST_STUDENT_NUMBER, TEST_EMAIL, TEST_NAME, TEST_ROLE);
-        verify(jwtTokenProvider, times(1)).generateRefreshToken(TEST_MEMBER_ID);
+        verify(jwtTokenProvider, never()).generateRefreshToken(any());
+        verify(authDomainService, never()).saveRefreshToken(any());
     }
 }

--- a/src/test/java/org/certis/studyplatform/auth/application/service/AuthFacadeServiceTest.java
+++ b/src/test/java/org/certis/studyplatform/auth/application/service/AuthFacadeServiceTest.java
@@ -101,13 +101,12 @@ class AuthFacadeServiceTest {
     }
 
     @Test
-    @DisplayName("토큰 갱신 성공 - 토큰 로테이션 검증")
+    @DisplayName("토큰 갱신 성공 - AccessToken만 재발급 (로테이션 없음)")
     void refreshAccessToken_Success_TokenRotation() {
         // Given
         when(jwtTokenProvider.getUserIdFromToken(TEST_REFRESH_TOKEN)).thenReturn(TEST_MEMBER_ID);
         when(authQueryService.validateRefreshToken(any(ValidateRefreshTokenQuery.class)))
-                .thenReturn(mockRefreshToken)  // 첫 번째 호출: 기존 토큰 검증
-                .thenReturn(mockNewRefreshToken); // 두 번째 호출: 새 토큰 조회
+                .thenReturn(mockRefreshToken);
         when(memberQueryService.getMemberTokenInfo(any(GetMemberTokenInfoQuery.class)))
                 .thenReturn(mockMemberInfo);
         when(authCommandService.refreshAccessToken(any(RefreshTokenCommand.class)))
@@ -120,9 +119,9 @@ class AuthFacadeServiceTest {
         assertThat(result).isNotNull();
         assertThat(result.getAccessToken()).isEqualTo(TEST_NEW_ACCESS_TOKEN);
 
-        // 토큰 로테이션 검증: 새로운 RefreshToken이 생성되었는지 확인
+        // AccessToken만 재발급, RefreshToken 로테이션/재조회 없음
         verify(authCommandService, times(1)).refreshAccessToken(any(RefreshTokenCommand.class));
-        verify(authQueryService, times(2)).validateRefreshToken(any(ValidateRefreshTokenQuery.class));
+        verify(authQueryService, times(1)).validateRefreshToken(any(ValidateRefreshTokenQuery.class));
     }
 
     @Test

--- a/src/test/java/org/certis/studyplatform/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/org/certis/studyplatform/auth/presentation/AuthControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import static org.mockito.Mockito.*;
+import jakarta.servlet.http.Cookie;
 
 
 import java.time.OffsetDateTime;
@@ -296,20 +297,31 @@ class AuthControllerTest {
                 .andExpect(status().isOk())
                 .andReturn();
 
-        // 로그인 응답에서 RefreshToken 추출
-        String loginResponseBody = loginResult.getResponse().getContentAsString();
-        String originalRefreshToken = objectMapper.readTree(loginResponseBody)
-                .path("data")
-                .path("refreshToken")
-                .asText();
+        // 로그인 응답 쿠키에서 RefreshToken 추출
+        Cookie[] cookies = loginResult.getResponse().getCookies();
+        String originalRefreshToken = java.util.Arrays.stream(cookies)
+                .filter(c -> "refreshToken".equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+        assertThat(originalRefreshToken).isNotBlank();
+
+        // Redis에 기존 RefreshToken 이 저장되어 있다고 가정
+        when(redisRefreshTokenRepository.findByMemberId(any()))
+                .thenReturn(java.util.Optional.of(
+                        new org.certis.studyplatform.auth.domain.model.vo.RefreshTokenVo(
+                                originalRefreshToken,
+                                java.time.LocalDateTime.now().plusDays(1),
+                                TEST_MEMBER_ID
+                        )
+                ));
 
         // When: 토큰 갱신 요청
         MvcResult refreshResult = mockMvc.perform(post(BASE_URL + "/token/refresh")
-                        .header("Cookie", "refreshToken=" + originalRefreshToken))
+                        .cookie(new Cookie("refreshToken", originalRefreshToken)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.accessToken").exists())
-                .andExpect(jsonPath("$.data.refreshToken").exists())
                 .andReturn();
 
         // Then: 토큰 로테이션 검증
@@ -318,18 +330,12 @@ class AuthControllerTest {
                 .path("data")
                 .path("accessToken")
                 .asText();
-        String newRefreshToken = objectMapper.readTree(refreshResponseBody)
-                .path("data")
-                .path("refreshToken")
-                .asText();
-
-        // 새로운 토큰들이 생성되었는지 확인
+        
+        // 새로운 AccessToken 이 생성되었는지 확인 (리프레시 토큰 로테이션 없음)
         assertThat(newAccessToken).isNotEmpty();
-        assertThat(newRefreshToken).isNotEmpty();
-        assertThat(newRefreshToken).isNotEqualTo(originalRefreshToken);
-
-        // Redis에서 토큰 저장이 호출되었는지 확인 (토큰 로테이션)
-        verify(redisRefreshTokenRepository, atLeast(2)).save(any(), any());
+        
+        // 로그인 시 저장은 최소 1회 호출됨. 리프레시 동작에 대한 추가 호출은 보장하지 않음.
+        verify(redisRefreshTokenRepository, atLeastOnce()).save(any(), any());
     }
 
     @Test

--- a/src/test/java/org/certis/studyplatform/shared/config/JacksonConfigurationTest.java
+++ b/src/test/java/org/certis/studyplatform/shared/config/JacksonConfigurationTest.java
@@ -1,0 +1,48 @@
+package org.certis.studyplatform.shared.config;
+
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(classes = JacksonConfiguration.class)
+class JacksonConfigurationTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private record LargePayload(String data) {}
+
+    @Test
+    @DisplayName("Configured ObjectMapper can read >20MB JSON string field")
+    void objectMapper_canDeserialize_oversizedString_over20MB() throws Exception {
+        int sizeOver20Mb = 21_000_000; // characters; Jackson's limit is in characters
+
+        String big = "A".repeat(sizeOver20Mb);
+        String json = "{\"data\":\"" + big + "\"}";
+
+        LargePayload payload = objectMapper.readValue(json, LargePayload.class);
+
+        assertThat(payload).isNotNull();
+        assertThat(payload.data()).hasSize(sizeOver20Mb);
+    }
+
+    @Test
+    @DisplayName("Sanity: default ObjectMapper without custom constraints would fail for >20MB")
+    void defaultObjectMapper_wouldFail_withoutRelaxedConstraints() {
+        ObjectMapper defaultMapper = new ObjectMapper();
+
+        int sizeOver20Mb = 21_000_000;
+        String big = "B".repeat(sizeOver20Mb);
+        String json = "{\"data\":\"" + big + "\"}";
+
+        assertThatThrownBy(() -> defaultMapper.readValue(json, LargePayload.class))
+                .hasRootCauseInstanceOf(StreamConstraintsException.class);
+    }
+}
+


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#84, #85

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- Jackson Config Request 제한 20MB => 100MB
-  Board 작성/편집/삭제 권한 승인된 유저 모두에게 권한 부여
- RefreshToken 전략 Rollback

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
