### PR TITLE
보고서 제출 리팩토링 개인프로필 조회 시 null value field 추가 및 리프레시 토큰 경로 수정

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
 # Use official OpenJDK base image
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21-jdk-jammy
 
 # Install curl and unzip
 RUN apt-get update && apt-get install -y curl unzip

--- a/src/main/java/org/certis/studyplatform/member/presentation/dto/response/ProfileInfoResponseDto.java
+++ b/src/main/java/org/certis/studyplatform/member/presentation/dto/response/ProfileInfoResponseDto.java
@@ -1,5 +1,6 @@
 package org.certis.studyplatform.member.presentation.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +18,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.ALWAYS)
 public class ProfileInfoResponseDto {
     private Long memberId;
     private String name;

--- a/src/main/java/org/certis/studyplatform/project/domain/repository/ProjectQueryRepository.java
+++ b/src/main/java/org/certis/studyplatform/project/domain/repository/ProjectQueryRepository.java
@@ -153,10 +153,10 @@ public interface ProjectQueryRepository {
     List<Long> findApprovedProjectsStartedBefore(OffsetDateTime currentTime);
 
     /**
-     * 프로젝트 엔티티 직접 조회 (상태 업데이트용)
-     * 
+     * 프로젝트 상태 검증용 VO 조회 (엔티티의 명시 상태 기준으로 매핑)
+     *
      * @param projectId 프로젝트 ID
-     * @return 프로젝트 엔티티
+     * @return 프로젝트 VO (DB status를 그대로 반영)
      */
-    java.util.Optional<org.certis.studyplatform.project.infrastructure.persistence.entity.ProjectEntity> findEntityById(Long projectId);
+    Optional<ProjectVo> findVoByIdForStatusCheck(Long projectId);
 }

--- a/src/main/java/org/certis/studyplatform/project/domain/service/ProjectProgressStatusEventListener.java
+++ b/src/main/java/org/certis/studyplatform/project/domain/service/ProjectProgressStatusEventListener.java
@@ -7,6 +7,7 @@ import org.certis.studyplatform.shared.domain.service.ProgressStatusService;
 import org.certis.studyplatform.project.domain.ProjectStatus;
 import org.certis.studyplatform.project.domain.repository.ProjectCommandRepository;
 import org.certis.studyplatform.project.domain.repository.ProjectQueryRepository;
+import org.certis.studyplatform.project.domain.vo.ProjectVo;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,33 +35,39 @@ public class ProjectProgressStatusEventListener {
 
         try {
             log.info("Processing project progress status update for project ID: {}", event.getEntityId());
-            
-            var projectEntity = projectQueryRepository.findEntityById(event.getEntityId());
-            if (projectEntity.isEmpty()) {
+
+            var projectVoOpt = projectQueryRepository.findVoByIdForStatusCheck(event.getEntityId());
+            if (projectVoOpt.isEmpty()) {
                 log.warn("Project not found with ID: {}", event.getEntityId());
                 return;
             }
 
-            var entity = projectEntity.get();
+            var vo = projectVoOpt.get();
             var currentTime = event.getCurrentTime();
             
             // 현재 시간이 started_at 이후인지 확인
-            if (currentTime.isAfter(entity.getStartedAt())) {
+            if (currentTime.isAfter(vo.startDate())) {
                 var result = progressStatusService.calculateProjectStatus(
-                    entity.getStatus(),
-                    entity.getResultSubmitStatus(),
-                    entity.getStartedAt(),
-                    entity.getEndedAt(),
+                    ProjectStatus.valueOf(vo.status()),
+                    vo.resultSubmitStatus(),
+                    vo.startDate(),
+                    vo.endDate(),
                     currentTime
                 );
 
                 // 상태가 변경된 경우에만 업데이트
-                if (!entity.getStatus().equals(result.status()) || 
-                    !entity.getResultSubmitStatus().equals(result.resultSubmitStatus())) {
-                    
-                    entity.setStatus((ProjectStatus) result.status());
-                    entity.setResultSubmitStatus(result.resultSubmitStatus());
-                    projectCommandRepository.save(entity);
+                if (!ProjectStatus.valueOf(vo.status()).equals(result.status()) || 
+                    !vo.resultSubmitStatus().equals(result.resultSubmitStatus())) {
+
+                    ProjectVo updated = ProjectVo.of(
+                        vo.id(), vo.title(), vo.description(), vo.content(), vo.category(), vo.subCategory(),
+                        vo.startDate(), vo.endDate(), vo.creatorId(), vo.creatorName(), vo.creatorGrade(),
+                        vo.semester(), ((ProjectStatus) result.status()).name(), result.resultSubmitStatus(),
+                        vo.githubUrl(), vo.externalUrl(), vo.demoUrl(), vo.thumbnailUrl(),
+                        vo.maxParticipants(), vo.currentParticipants(), vo.isParticipantable(),
+                        vo.attached(), vo.meetingSummaryVos()
+                    );
+                    projectCommandRepository.save(updated);
                     
                     log.info("Updated project {} status to {} and resultSubmitStatus to {}", 
                         event.getEntityId(), result.status(), result.resultSubmitStatus());

--- a/src/main/java/org/certis/studyplatform/project/infrastructure/persistence/ProjectQueryRepositoryImpl.java
+++ b/src/main/java/org/certis/studyplatform/project/infrastructure/persistence/ProjectQueryRepositoryImpl.java
@@ -1194,43 +1194,40 @@ public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
     }
 
     @Override
-    public Optional<org.certis.studyplatform.project.infrastructure.persistence.entity.ProjectEntity> findEntityById(Long projectId) {
-        log.info("jOOQ: Finding project entity by ID - {}", projectId);
-        
-        // JOOQ를 통해 Entity 직접 조회
+    public Optional<ProjectVo> findVoByIdForStatusCheck(Long projectId) {
+        log.info("jOOQ: Finding project VO (for status check) by ID - {}", projectId);
+
         return Optional.ofNullable(
-            dsl.selectFrom(PROJECT)
-                .where(PROJECT.ID.eq(projectId))
-                .and(PROJECT.DELETED_AT.isNull())
-                .fetchOne()
+                dsl.selectFrom(PROJECT)
+                        .where(PROJECT.ID.eq(projectId))
+                        .and(PROJECT.DELETED_AT.isNull())
+                        .fetchOne()
         ).map(record -> {
-            // Record를 ProjectEntity로 변환
-            return org.certis.studyplatform.project.infrastructure.persistence.entity.ProjectEntity.builder()
-                .id(record.get(PROJECT.ID))
-                .memberId(record.get(PROJECT.MEMBER_ID))
-                .title(record.get(PROJECT.TITLE))
-                .description(record.get(PROJECT.DESCRIPTION))
-                .content(record.get(PROJECT.CONTENT))
-                .category(record.get(PROJECT.CATEGORY))
-                .subcategory(record.get(PROJECT.SUBCATEGORY))
-                .maxParticipantsNumber(record.get(PROJECT.MAX_PARTICIPANTS_NUMBER))
-                .githubUrl(record.get(PROJECT.GITHUB_URL))
-                .externalUrl(record.get(PROJECT.EXTERNAL_URL))
-                .demoUrl(record.get(PROJECT.DEMO_URL))
-                .thumbnailUrl(record.get(PROJECT.THUMBNAIL_URL))
-                .startedAt(record.get(PROJECT.STARTED_AT))
-                .endedAt(record.get(PROJECT.ENDED_AT))
-                .createdAt(record.get(PROJECT.CREATED_AT))
-                .updatedAt(record.get(PROJECT.UPDATED_AT))
-                .deletedAt(record.get(PROJECT.DELETED_AT))
-                .resultSubmittedAt(record.get(PROJECT.RESULT_SUBMITTED_AT))
-                .resultSubmitStatus(record.get(PROJECT.RESULT_SUBMIT_STATUS) != null ? 
-                    org.certis.studyplatform.shared.domain.ResultSubmitStatus.valueOf(record.get(PROJECT.RESULT_SUBMIT_STATUS)) : null)
-                .resultAttachmentUrl(record.get(PROJECT.RESULT_ATTACHED_URL))
-                .status(record.get(PROJECT.STATUS) != null ? 
-                    org.certis.studyplatform.project.domain.ProjectStatus.valueOf(record.get(PROJECT.STATUS)) : 
-                    org.certis.studyplatform.project.domain.ProjectStatus.READY)
-                .build();
+            var entity = org.certis.studyplatform.project.infrastructure.persistence.entity.ProjectEntity.builder()
+                    .id(record.get(PROJECT.ID))
+                    .memberId(record.get(PROJECT.MEMBER_ID))
+                    .title(record.get(PROJECT.TITLE))
+                    .description(record.get(PROJECT.DESCRIPTION))
+                    .content(record.get(PROJECT.CONTENT))
+                    .category(record.get(PROJECT.CATEGORY))
+                    .subcategory(record.get(PROJECT.SUBCATEGORY))
+                    .maxParticipantsNumber(record.get(PROJECT.MAX_PARTICIPANTS_NUMBER))
+                    .githubUrl(record.get(PROJECT.GITHUB_URL))
+                    .externalUrl(record.get(PROJECT.EXTERNAL_URL))
+                    .demoUrl(record.get(PROJECT.DEMO_URL))
+                    .thumbnailUrl(record.get(PROJECT.THUMBNAIL_URL))
+                    .startedAt(record.get(PROJECT.STARTED_AT))
+                    .endedAt(record.get(PROJECT.ENDED_AT))
+                    .createdAt(record.get(PROJECT.CREATED_AT))
+                    .updatedAt(record.get(PROJECT.UPDATED_AT))
+                    .deletedAt(record.get(PROJECT.DELETED_AT))
+                    .resultSubmittedAt(record.get(PROJECT.RESULT_SUBMITTED_AT))
+                    .resultSubmitStatus(record.get(PROJECT.RESULT_SUBMIT_STATUS) != null ?
+                            ResultSubmitStatus.valueOf(record.get(PROJECT.RESULT_SUBMIT_STATUS)) : ResultSubmitStatus.READY)
+                    .status(record.get(PROJECT.STATUS) != null ?
+                            ProjectStatus.valueOf(record.get(PROJECT.STATUS)) : ProjectStatus.READY)
+                    .build();
+            return mapper.toVo(entity);
         });
     }
 }

--- a/src/main/java/org/certis/studyplatform/shared/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/certis/studyplatform/shared/security/JwtAuthenticationFilter.java
@@ -121,7 +121,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 "/api/v1/member/**",
                 "/api/v1/auth/login",
                 "/api/v1/auth/register",  // 회원가입 추가
-                "/api/v1/auth/refresh",   // 토큰 갱신
+                "/api/v1/auth/token/refresh",   // 토큰 갱신
                 "/api/v1/blog",              // 블로그 목록 조회
                 "/api/v1/blog/detail",       // 블로그 상세 조회
                 "/api/v1/blog/search",       // 블로그 검색

--- a/src/main/java/org/certis/studyplatform/study/domain/repository/StudyQueryRepository.java
+++ b/src/main/java/org/certis/studyplatform/study/domain/repository/StudyQueryRepository.java
@@ -111,12 +111,12 @@ public interface StudyQueryRepository {
     List<Long> findApprovedStudiesStartedBefore(OffsetDateTime currentTime);
 
     /**
-     * 스터디 엔티티 직접 조회 (상태 업데이트용)
-     * 
+     * 스터디 상태 검증용 VO 조회 (엔티티의 명시 상태 기준으로 매핑)
+     *
      * @param studyId 스터디 ID
-     * @return 스터디 엔티티
+     * @return 스터디 VO (DB status를 그대로 반영)
      */
-    java.util.Optional<org.certis.studyplatform.study.infrastructure.persistence.entity.StudyEntity> findEntityById(Long studyId);
+    Optional<StudyVo> findVoByIdForStatusCheck(Long studyId);
 
 
     /**

--- a/src/main/java/org/certis/studyplatform/study/domain/service/StudyDomainService.java
+++ b/src/main/java/org/certis/studyplatform/study/domain/service/StudyDomainService.java
@@ -413,16 +413,22 @@ public class StudyDomainService {
     public StudyVo endStudy(EndStudyCommand command) {
         log.info("Domain: Ending study from command - ID: {}", command.studyId());
 
-        // 기존 스터디 조회
+        // 기존 스터디 조회 (VO와 Entity를 각각 조회)
+        // VO는 반환 용도로 사용하고, 상태 검증은 엔티티의 DB 상태로만 판단한다.
         StudyVo existingStudy = queryRepository.findById(command.studyId())
                 .orElseThrow(() -> new DomainException(ExceptionStatus.STUDY_DOMAIN_NOT_FOUND,
                         "스터디를 찾을 수 없습니다: " + command.studyId()));
 
+        StudyVo statusCheckVo =
+                queryRepository.findVoByIdForStatusCheck(command.studyId())
+                        .orElseThrow(() -> new DomainException(ExceptionStatus.STUDY_DOMAIN_NOT_FOUND,
+                                "스터디를 찾을 수 없습니다: " + command.studyId()));
+
         // 권한 검증: STAFF 이상이거나 스터디 생성자인지 확인
         validateStudyEndPermission(command.requesterId(), existingStudy.creatorId());
 
-        // 이미 종료된 스터디인지 검증 (시간 비교가 아닌, DB에 저장된 status 기준)
-        if (StudyStatus.fromStatusString(existingStudy.status()).isCompleted()) {
+        // 이미 종료된 스터디인지 검증 (endedAt 무관, DB status 기준)
+        if (StudyStatus.fromStatusString(statusCheckVo.status()).isCompleted()) {
             throw new DomainException(ExceptionStatus.STUDY_DOMAIN_RULE_VIOLATION,
                     "이미 종료된 스터디입니다");
         }

--- a/src/main/java/org/certis/studyplatform/study/domain/service/StudyProgressStatusEventListener.java
+++ b/src/main/java/org/certis/studyplatform/study/domain/service/StudyProgressStatusEventListener.java
@@ -10,6 +10,7 @@ import org.certis.studyplatform.study.domain.repository.StudyQueryRepository;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.certis.studyplatform.study.domain.vo.StudyVo;
 
 /**
  * Study Progress Status Event Listener
@@ -35,32 +36,39 @@ public class StudyProgressStatusEventListener {
         try {
             log.info("Processing study progress status update for study ID: {}", event.getEntityId());
             
-            var studyEntity = studyQueryRepository.findEntityById(event.getEntityId());
-            if (studyEntity.isEmpty()) {
+            var studyVoOpt = studyQueryRepository.findVoByIdForStatusCheck(event.getEntityId());
+            if (studyVoOpt.isEmpty()) {
                 log.warn("Study not found with ID: {}", event.getEntityId());
                 return;
             }
 
-            var entity = studyEntity.get();
+            var vo = studyVoOpt.get();
             var currentTime = event.getCurrentTime();
             
             // 현재 시간이 started_at 이후인지 확인
-            if (currentTime.isAfter(entity.getStartedAt())) {
+            if (currentTime.isAfter(vo.startDate())) {
                 var result = progressStatusService.calculateStudyStatus(
-                    entity.getStatus(),
-                    entity.getResultSubmitStatus(),
-                    entity.getStartedAt(),
-                    entity.getEndedAt(),
+                    org.certis.studyplatform.study.domain.StudyStatus.fromStatusString(vo.status()),
+                    vo.resultSubmitStatus(),
+                    vo.startDate(),
+                    vo.endDate(),
                     currentTime
                 );
 
                 // 상태가 변경된 경우에만 업데이트
-                if (!entity.getStatus().equals(result.status()) || 
-                    !entity.getResultSubmitStatus().equals(result.resultSubmitStatus())) {
-                    
-                    entity.setStatus((StudyStatus) result.status());
-                    entity.setResultSubmitStatus(result.resultSubmitStatus());
-                    studyCommandRepository.save(entity);
+                if (!org.certis.studyplatform.study.domain.StudyStatus.fromStatusString(vo.status()).equals(result.status()) || 
+                    !vo.resultSubmitStatus().equals(result.resultSubmitStatus())) {
+                    // 변경된 상태를 반영한 VO 저장
+                    StudyVo updated = new StudyVo(
+                        vo.id(), vo.title(), vo.description(), vo.content(), vo.category(), vo.subCategory(),
+                        vo.startDate(), vo.endDate(), vo.createdAt(), vo.updatedAt(), vo.creatorId(), vo.creatorName(),
+                        vo.creatorGrade(), vo.creatorProfileImageUrl(), vo.semester(),
+                        ((org.certis.studyplatform.study.domain.StudyStatus) result.status()).name(),
+                        result.resultSubmitStatus(),
+                        vo.maxParticipants(), vo.currentParticipants(), vo.isParticipantable(),
+                        vo.attached(), vo.summaryVoList(), vo.participantVoList()
+                    );
+                    studyCommandRepository.save(updated);
                     
                     log.info("Updated study {} status to {} and resultSubmitStatus to {}", 
                         event.getEntityId(), result.status(), result.resultSubmitStatus());

--- a/src/main/java/org/certis/studyplatform/study/infrastructure/persistence/StudyQueryRepositoryImpl.java
+++ b/src/main/java/org/certis/studyplatform/study/infrastructure/persistence/StudyQueryRepositoryImpl.java
@@ -1212,39 +1212,40 @@ public class StudyQueryRepositoryImpl implements StudyQueryRepository {
     }
 
     @Override
-    public Optional<StudyEntity> findEntityById(Long studyId) {
-        log.info("jOOQ: Finding study entity by ID - {}", studyId);
-        
-        // JPA Repository를 통해 Entity 직접 조회
+    public Optional<StudyVo> findVoByIdForStatusCheck(Long studyId) {
+        log.info("jOOQ: Finding study VO (for status check) by ID - {}", studyId);
+
         return Optional.ofNullable(
-            dsl.selectFrom(STUDY)
-                .where(STUDY.ID.eq(studyId))
-                .and(STUDY.DELETED_AT.isNull())
-                .fetchOne()
+                dsl.selectFrom(STUDY)
+                        .where(STUDY.ID.eq(studyId))
+                        .and(STUDY.DELETED_AT.isNull())
+                        .fetchOne()
         ).map(record -> {
-            // Record를 StudyEntity로 변환
-            return StudyEntity.builder()
-                .id(record.get(STUDY.ID))
-                .memberId(record.get(STUDY.MEMBER_ID))
-                .title(record.get(STUDY.TITLE))
-                .description(record.get(STUDY.DESCRIPTION))
-                .content(record.get(STUDY.CONTENT))
-                .category(record.get(STUDY.CATEGORY))
-                .subcategory(record.get(STUDY.SUBCATEGORY))
-                .maxParticipantsNumber(record.get(STUDY.MAX_PARTICIPANTS_NUMBER))
-                .startedAt(record.get(STUDY.STARTED_AT))
-                .endedAt(record.get(STUDY.ENDED_AT))
-                .createdAt(record.get(STUDY.CREATED_AT))
-                .updatedAt(record.get(STUDY.UPDATED_AT))
-                .deletedAt(record.get(STUDY.DELETED_AT))
-                .resultSubmittedAt(record.get(STUDY.RESULT_SUBMITTED_AT))
-                .resultSubmitStatus(record.get(STUDY.RESULT_SUBMIT_STATUS) != null ? 
-                    ResultSubmitStatus.valueOf(record.get(STUDY.RESULT_SUBMIT_STATUS)) : null)
-                .resultAttachmentUrl(record.get(STUDY.RESULT_ATTACHED_URL))
-                .status(record.get(STUDY.STATUS) != null ? 
-                    StudyStatus.valueOf(record.get(STUDY.STATUS)) : 
-                    StudyStatus.READY)
-                .build();
+            // Record를 StudyEntity로 변환 후 Mapper를 통해 VO로 매핑 (엔티티의 명시 status 사용)
+            StudyEntity entity = StudyEntity.builder()
+                    .id(record.get(STUDY.ID))
+                    .memberId(record.get(STUDY.MEMBER_ID))
+                    .title(record.get(STUDY.TITLE))
+                    .description(record.get(STUDY.DESCRIPTION))
+                    .content(record.get(STUDY.CONTENT))
+                    .category(record.get(STUDY.CATEGORY))
+                    .subcategory(record.get(STUDY.SUBCATEGORY))
+                    .maxParticipantsNumber(record.get(STUDY.MAX_PARTICIPANTS_NUMBER))
+                    .startedAt(record.get(STUDY.STARTED_AT))
+                    .endedAt(record.get(STUDY.ENDED_AT))
+                    .createdAt(record.get(STUDY.CREATED_AT))
+                    .updatedAt(record.get(STUDY.UPDATED_AT))
+                    .deletedAt(record.get(STUDY.DELETED_AT))
+                    .resultSubmittedAt(record.get(STUDY.RESULT_SUBMITTED_AT))
+                    .resultSubmitStatus(record.get(STUDY.RESULT_SUBMIT_STATUS) != null ?
+                            ResultSubmitStatus.valueOf(record.get(STUDY.RESULT_SUBMIT_STATUS)) : ResultSubmitStatus.READY)
+                    .resultAttachmentUrl(record.get(STUDY.RESULT_ATTACHED_URL))
+                    .status(record.get(STUDY.STATUS) != null ?
+                            StudyStatus.valueOf(record.get(STUDY.STATUS)) :
+                            StudyStatus.READY)
+                    .build();
+
+            return mapper.toVo(entity);
         });
     }
 }

--- a/src/test/java/org/certis/studyplatform/integration/NewFeaturesIntegrationTest.java
+++ b/src/test/java/org/certis/studyplatform/integration/NewFeaturesIntegrationTest.java
@@ -318,7 +318,7 @@ class NewFeaturesIntegrationTest {
                 .andExpect(status().isBadRequest()); // validation 에러로 400
         
         // 3. 토큰 갱신 엔드포인트도 인증 없이 접근 가능
-        mockMvc.perform(post("/api/v1/auth/refresh")
+        mockMvc.perform(post("/api/v1/auth/token/refresh")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}"))
                 .andDo(print())

--- a/src/test/java/org/certis/studyplatform/integration/NewFeaturesIntegrationTest.java
+++ b/src/test/java/org/certis/studyplatform/integration/NewFeaturesIntegrationTest.java
@@ -317,12 +317,12 @@ class NewFeaturesIntegrationTest {
                 .andDo(print())
                 .andExpect(status().isBadRequest()); // validation 에러로 400
         
-        // 3. 토큰 갱신 엔드포인트도 인증 없이 접근 가능
+        // 3. 토큰 갱신 엔드포인트 - 인증 필요로 401 반환
         mockMvc.perform(post("/api/v1/auth/token/refresh")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}"))
                 .andDo(print())
-                .andExpect(status().isNotFound()); // 컨트롤러가 없어서 404
+                .andExpect(status().isUnauthorized()); // 인증 필요로 401
     }
 
     @Test

--- a/src/test/java/org/certis/studyplatform/project/domain/service/ProjectProgressStatusEventListenerTest.java
+++ b/src/test/java/org/certis/studyplatform/project/domain/service/ProjectProgressStatusEventListenerTest.java
@@ -4,7 +4,7 @@ import org.certis.studyplatform.shared.domain.ResultSubmitStatus;
 import org.certis.studyplatform.shared.domain.event.ProgressStatusUpdateEvent;
 import org.certis.studyplatform.shared.domain.service.ProgressStatusService;
 import org.certis.studyplatform.project.domain.ProjectStatus;
-import org.certis.studyplatform.project.infrastructure.persistence.entity.ProjectEntity;
+import org.certis.studyplatform.project.domain.vo.ProjectVo;
 import org.certis.studyplatform.project.domain.repository.ProjectCommandRepository;
 import org.certis.studyplatform.project.domain.repository.ProjectQueryRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,15 +56,25 @@ class ProjectProgressStatusEventListenerTest {
         OffsetDateTime currentTime = OffsetDateTime.now();
         ProgressStatusUpdateEvent event = ProgressStatusUpdateEvent.forProject(projectId, currentTime);
 
-        ProjectEntity projectEntity = ProjectEntity.builder()
-            .id(projectId)
-            .status(ProjectStatus.APPROVED)
-            .resultSubmitStatus(ResultSubmitStatus.READY)
-            .startedAt(currentTime.minusHours(1))
-            .endedAt(currentTime.plusDays(1))
-            .build();
+        ProjectVo projectVo = ProjectVo.of(
+            projectId,
+            "t", "d", "c",
+            "cat", "sub",
+            currentTime.minusHours(1),
+            currentTime.plusDays(1),
+            10L,
+            "creator", null,
+            null,
+            ProjectStatus.APPROVED.name(),
+            ResultSubmitStatus.READY,
+            null, (org.certis.studyplatform.project.domain.vo.ExternalUrlVo) null, null, null,
+            5, 0,
+            false,
+            java.util.Collections.emptyList(),
+            java.util.Collections.emptyList()
+        );
 
-        when(projectQueryRepository.findEntityById(projectId)).thenReturn(Optional.of(projectEntity));
+        when(projectQueryRepository.findVoByIdForStatusCheck(projectId)).thenReturn(Optional.of(projectVo));
         when(progressStatusService.calculateProjectStatus(
             any(), any(), any(), any(), any()
         )).thenReturn(new ProgressStatusService.ProgressStatusResult(
@@ -75,12 +85,12 @@ class ProjectProgressStatusEventListenerTest {
         eventListener.handleProgressStatusUpdate(event);
 
         // Then
-        ArgumentCaptor<ProjectEntity> captor = ArgumentCaptor.forClass(ProjectEntity.class);
+        ArgumentCaptor<ProjectVo> captor = ArgumentCaptor.forClass(ProjectVo.class);
         verify(projectCommandRepository).save(captor.capture());
         
-        ProjectEntity savedEntity = captor.getValue();
-        assertThat(savedEntity.getStatus()).isEqualTo(ProjectStatus.INPROGRESS);
-        assertThat(savedEntity.getResultSubmitStatus()).isEqualTo(ResultSubmitStatus.READY);
+        ProjectVo savedVo = captor.getValue();
+        assertThat(savedVo.status()).isEqualTo(ProjectStatus.INPROGRESS.name());
+        assertThat(savedVo.resultSubmitStatus()).isEqualTo(ResultSubmitStatus.READY);
     }
 
     @Test
@@ -91,15 +101,25 @@ class ProjectProgressStatusEventListenerTest {
         OffsetDateTime currentTime = OffsetDateTime.now();
         ProgressStatusUpdateEvent event = ProgressStatusUpdateEvent.forProject(projectId, currentTime);
 
-        ProjectEntity projectEntity = ProjectEntity.builder()
-            .id(projectId)
-            .status(ProjectStatus.APPROVED)
-            .resultSubmitStatus(ResultSubmitStatus.READY)
-            .startedAt(currentTime.minusHours(1))
-            .endedAt(currentTime.plusDays(1))
-            .build();
+        ProjectVo projectVo2 = ProjectVo.of(
+            projectId,
+            "t", "d", "c",
+            "cat", "sub",
+            currentTime.minusHours(1),
+            currentTime.plusDays(1),
+            10L,
+            "creator", null,
+            null,
+            ProjectStatus.APPROVED.name(),
+            ResultSubmitStatus.READY,
+            null, (org.certis.studyplatform.project.domain.vo.ExternalUrlVo) null, null, null,
+            5, 0,
+            false,
+            java.util.Collections.emptyList(),
+            java.util.Collections.emptyList()
+        );
 
-        when(projectQueryRepository.findEntityById(projectId)).thenReturn(Optional.of(projectEntity));
+        when(projectQueryRepository.findVoByIdForStatusCheck(projectId)).thenReturn(Optional.of(projectVo2));
         when(progressStatusService.calculateProjectStatus(
             any(), any(), any(), any(), any()
         )).thenReturn(new ProgressStatusService.ProgressStatusResult(
@@ -110,7 +130,7 @@ class ProjectProgressStatusEventListenerTest {
         eventListener.handleProgressStatusUpdate(event);
 
         // Then
-        verify(projectCommandRepository, never()).save(any(org.certis.studyplatform.project.infrastructure.persistence.entity.ProjectEntity.class));
+        verify(projectCommandRepository, never()).save(any(ProjectVo.class));
     }
 
     @Test
@@ -121,13 +141,13 @@ class ProjectProgressStatusEventListenerTest {
         OffsetDateTime currentTime = OffsetDateTime.now();
         ProgressStatusUpdateEvent event = ProgressStatusUpdateEvent.forProject(projectId, currentTime);
 
-        when(projectQueryRepository.findEntityById(projectId)).thenReturn(Optional.empty());
+        when(projectQueryRepository.findVoByIdForStatusCheck(projectId)).thenReturn(Optional.empty());
 
         // When
         eventListener.handleProgressStatusUpdate(event);
 
         // Then
-        verify(projectCommandRepository, never()).save(any(org.certis.studyplatform.project.infrastructure.persistence.entity.ProjectEntity.class));
+        verify(projectCommandRepository, never()).save(any(ProjectVo.class));
         verify(progressStatusService, never()).calculateProjectStatus(any(), any(), any(), any(), any());
     }
 
@@ -139,21 +159,31 @@ class ProjectProgressStatusEventListenerTest {
         OffsetDateTime currentTime = OffsetDateTime.now();
         ProgressStatusUpdateEvent event = ProgressStatusUpdateEvent.forProject(projectId, currentTime);
 
-        ProjectEntity projectEntity = ProjectEntity.builder()
-            .id(projectId)
-            .status(ProjectStatus.APPROVED)
-            .resultSubmitStatus(ResultSubmitStatus.READY)
-            .startedAt(currentTime.plusHours(1)) // 미래 시간
-            .endedAt(currentTime.plusDays(1))
-            .build();
+        ProjectVo projectVo3 = ProjectVo.of(
+            projectId,
+            "t", "d", "c",
+            "cat", "sub",
+            currentTime.plusHours(1), // 미래 시간
+            currentTime.plusDays(1),
+            10L,
+            "creator", null,
+            null,
+            ProjectStatus.APPROVED.name(),
+            ResultSubmitStatus.READY,
+            null, (org.certis.studyplatform.project.domain.vo.ExternalUrlVo) null, null, null,
+            5, 0,
+            false,
+            java.util.Collections.emptyList(),
+            java.util.Collections.emptyList()
+        );
 
-        when(projectQueryRepository.findEntityById(projectId)).thenReturn(Optional.of(projectEntity));
+        when(projectQueryRepository.findVoByIdForStatusCheck(projectId)).thenReturn(Optional.of(projectVo3));
 
         // When
         eventListener.handleProgressStatusUpdate(event);
 
         // Then
-        verify(projectCommandRepository, never()).save(any(org.certis.studyplatform.project.infrastructure.persistence.entity.ProjectEntity.class));
+        verify(projectCommandRepository, never()).save(any(ProjectVo.class));
         verify(progressStatusService, never()).calculateProjectStatus(any(), any(), any(), any(), any());
     }
 
@@ -170,7 +200,7 @@ class ProjectProgressStatusEventListenerTest {
 
         // Then
         verify(projectQueryRepository, never()).findById(any());
-        verify(projectCommandRepository, never()).save(any(org.certis.studyplatform.project.infrastructure.persistence.entity.ProjectEntity.class));
+        verify(projectCommandRepository, never()).save(any(ProjectVo.class));
         verify(progressStatusService, never()).calculateProjectStatus(any(), any(), any(), any(), any());
     }
 }

--- a/src/test/java/org/certis/studyplatform/project/integration/ProjectEndApiE2ETest.java
+++ b/src/test/java/org/certis/studyplatform/project/integration/ProjectEndApiE2ETest.java
@@ -4,11 +4,15 @@ import org.certis.studyplatform.shared.domain.ResultSubmitStatus;
 import org.certis.studyplatform.project.application.ProjectFacadeService;
 import org.certis.studyplatform.project.presentation.dto.request.ProjectEndRequestDto;
 import org.certis.studyplatform.project.presentation.dto.response.ProjectDetailResponseDto;
+import org.certis.studyplatform.config.TestEmbeddedPostgresConfig;
+import org.certis.studyplatform.config.TestRedisMockConfig;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
@@ -18,6 +22,8 @@ import static org.certis.generated.jooq.Tables.MEMBER;
 import static org.certis.generated.jooq.Tables.PROJECT;
 
 @SpringBootTest
+@Import({TestEmbeddedPostgresConfig.class, TestRedisMockConfig.class})
+@ActiveProfiles("test")
 @Transactional
 class ProjectEndApiE2ETest {
 

--- a/src/test/java/org/certis/studyplatform/project/integration/ProjectEndApiE2ETest.java
+++ b/src/test/java/org/certis/studyplatform/project/integration/ProjectEndApiE2ETest.java
@@ -1,0 +1,87 @@
+package org.certis.studyplatform.project.integration;
+
+import org.certis.studyplatform.shared.domain.ResultSubmitStatus;
+import org.certis.studyplatform.project.application.ProjectFacadeService;
+import org.certis.studyplatform.project.presentation.dto.request.ProjectEndRequestDto;
+import org.certis.studyplatform.project.presentation.dto.response.ProjectDetailResponseDto;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.certis.generated.jooq.Tables.MEMBER;
+import static org.certis.generated.jooq.Tables.PROJECT;
+
+@SpringBootTest
+@Transactional
+class ProjectEndApiE2ETest {
+
+    @Autowired
+    private DSLContext dsl;
+
+    @Autowired
+    private ProjectFacadeService projectFacadeService;
+
+    @Test
+    @DisplayName("endProject ignores endedAt; relies on DB status/resultSubmitStatus only")
+    void endProject_ignoresEndedAt_whenStatusNotCompleted() {
+        // Given: Insert a project with ended_at in the past but status APPROVED (not COMPLETED)
+        OffsetDateTime now = OffsetDateTime.now();
+        Long creatorId = 303L;
+
+        // Satisfy FK: insert minimal member
+        dsl.insertInto(MEMBER)
+                .set(MEMBER.ID, creatorId)
+                .set(MEMBER.NAME, "creator-303")
+                .set(MEMBER.STUDENT_NUMBER, "20200002")
+                .set(MEMBER.ROLE, "PLAYER")
+                .set(MEMBER.GRADE, "JUNIOR")
+                .set(MEMBER.BIRTHDAY, now.minusYears(21))
+                .set(MEMBER.GENDER, "MALE")
+                .set(MEMBER.MAJOR, "CS")
+                .set(MEMBER.CREATED_AT, now)
+                .set(MEMBER.UPDATED_AT, now)
+                .onConflict(MEMBER.ID).doNothing()
+                .execute();
+
+        Long projectId = dsl.insertInto(PROJECT)
+                .set(PROJECT.MEMBER_ID, creatorId)
+                .set(PROJECT.TITLE, "E2E Project")
+                .set(PROJECT.DESCRIPTION, "desc")
+                .set(PROJECT.CONTENT, "content")
+                .set(PROJECT.CATEGORY, "CS")
+                .set(PROJECT.SUBCATEGORY, "BE")
+                .set(PROJECT.MAX_PARTICIPANTS_NUMBER, 5)
+                .set(PROJECT.STARTED_AT, now.minusDays(10))
+                .set(PROJECT.ENDED_AT, now.minusDays(1)) // past
+                .set(PROJECT.STATUS, "APPROVED") // not COMPLETED
+                .set(PROJECT.RESULT_SUBMIT_STATUS, ResultSubmitStatus.READY.name())
+                .set(PROJECT.CREATED_AT, now.minusDays(11))
+                .set(PROJECT.UPDATED_AT, now.minusDays(1))
+                .returning(PROJECT.ID)
+                .fetchOne()
+                .get(PROJECT.ID);
+
+        // When: call facade endProject with requester == creator
+        ProjectEndRequestDto req = new ProjectEndRequestDto();
+        try {
+            java.lang.reflect.Field f = ProjectEndRequestDto.class.getDeclaredField("projectId");
+            f.setAccessible(true);
+            f.set(req, projectId);
+        } catch (Exception ignore) {}
+
+        ProjectDetailResponseDto resp = projectFacadeService.endProject(req, creatorId);
+
+        // Then: success; endedAt past should not block since status != COMPLETED
+        assertThat(resp).isNotNull();
+        assertThat(resp.getId()).isEqualTo(projectId);
+    }
+}
+
+
+

--- a/src/test/java/org/certis/studyplatform/project/integration/ProjectQueryRepositoryStatusMappingTest.java
+++ b/src/test/java/org/certis/studyplatform/project/integration/ProjectQueryRepositoryStatusMappingTest.java
@@ -2,11 +2,15 @@ package org.certis.studyplatform.project.integration;
 
 import org.certis.studyplatform.project.domain.repository.ProjectQueryRepository;
 import org.certis.studyplatform.project.domain.vo.ProjectVo;
+import org.certis.studyplatform.config.TestEmbeddedPostgresConfig;
+import org.certis.studyplatform.config.TestRedisMockConfig;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
@@ -17,6 +21,8 @@ import static org.certis.generated.jooq.Tables.MEMBER;
 import static org.certis.generated.jooq.Tables.PROJECT;
 
 @SpringBootTest
+@Import({TestEmbeddedPostgresConfig.class, TestRedisMockConfig.class})
+@ActiveProfiles("test")
 @Transactional
 class ProjectQueryRepositoryStatusMappingTest {
 

--- a/src/test/java/org/certis/studyplatform/project/integration/ProjectQueryRepositoryStatusMappingTest.java
+++ b/src/test/java/org/certis/studyplatform/project/integration/ProjectQueryRepositoryStatusMappingTest.java
@@ -1,0 +1,75 @@
+package org.certis.studyplatform.project.integration;
+
+import org.certis.studyplatform.project.domain.repository.ProjectQueryRepository;
+import org.certis.studyplatform.project.domain.vo.ProjectVo;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.certis.generated.jooq.Tables.MEMBER;
+import static org.certis.generated.jooq.Tables.PROJECT;
+
+@SpringBootTest
+@Transactional
+class ProjectQueryRepositoryStatusMappingTest {
+
+    @Autowired
+    private DSLContext dsl;
+
+    @Autowired
+    private ProjectQueryRepository projectQueryRepository;
+
+    @Test
+    @DisplayName("findVoByIdForStatusCheck returns DB status as-is, ignoring endedAt (Project)")
+    void findVoByIdForStatusCheck_mapsDbStatusIgnoringEndedAt_project() {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        // Satisfy FK: insert minimal member
+        dsl.insertInto(MEMBER)
+                .set(MEMBER.ID, 404L)
+                .set(MEMBER.NAME, "tester-404")
+                .set(MEMBER.STUDENT_NUMBER, "20200004")
+                .set(MEMBER.ROLE, "PLAYER")
+                .set(MEMBER.GRADE, "JUNIOR")
+                .set(MEMBER.BIRTHDAY, now.minusYears(22))
+                .set(MEMBER.GENDER, "MALE")
+                .set(MEMBER.MAJOR, "CS")
+                .set(MEMBER.CREATED_AT, now)
+                .set(MEMBER.UPDATED_AT, now)
+                .onConflict(MEMBER.ID).doNothing()
+                .execute();
+
+        Long projectId = dsl.insertInto(PROJECT)
+                .set(PROJECT.MEMBER_ID, 404L)
+                .set(PROJECT.TITLE, "status-check-proj")
+                .set(PROJECT.DESCRIPTION, "desc")
+                .set(PROJECT.CONTENT, "content")
+                .set(PROJECT.CATEGORY, "CS")
+                .set(PROJECT.SUBCATEGORY, "BE")
+                .set(PROJECT.MAX_PARTICIPANTS_NUMBER, 5)
+                .set(PROJECT.STARTED_AT, now.minusDays(10))
+                .set(PROJECT.ENDED_AT, now.minusDays(1))
+                .set(PROJECT.STATUS, "APPROVED")
+                .set(PROJECT.RESULT_SUBMIT_STATUS, "READY")
+                .set(PROJECT.CREATED_AT, now.minusDays(11))
+                .set(PROJECT.UPDATED_AT, now.minusDays(1))
+                .returning(PROJECT.ID)
+                .fetchOne()
+                .get(PROJECT.ID);
+
+        Optional<ProjectVo> voOpt = projectQueryRepository.findVoByIdForStatusCheck(projectId);
+
+        assertThat(voOpt).isPresent();
+        assertThat(voOpt.get().status()).isEqualTo("APPROVED");
+    }
+}
+
+
+

--- a/src/test/java/org/certis/studyplatform/study/domain/service/StudyDomainServiceStatusValidationTest.java
+++ b/src/test/java/org/certis/studyplatform/study/domain/service/StudyDomainServiceStatusValidationTest.java
@@ -12,6 +12,8 @@ import org.certis.studyplatform.study.domain.repository.StudyParticipantQueryRep
 import org.certis.studyplatform.study.domain.repository.StudyQueryRepository;
 import org.certis.studyplatform.study.domain.vo.StudyVo;
 import org.certis.studyplatform.shared.domain.ResultSubmitStatus;
+import org.certis.studyplatform.study.infrastructure.persistence.entity.StudyEntity;
+import org.certis.studyplatform.study.domain.StudyStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -69,6 +71,25 @@ class StudyDomainServiceStatusValidationTest {
         );
 
         when(queryRepository.findById(studyId)).thenReturn(Optional.of(completed));
+        when(queryRepository.findVoByIdForStatusCheck(studyId)).thenReturn(Optional.of(
+                StudyVo.of(
+                        studyId,
+                        "t", "d", "c",
+                        "cat", "sub",
+                        OffsetDateTime.now().minusDays(10),
+                        OffsetDateTime.now().minusDays(1),
+                        OffsetDateTime.now().minusDays(10),
+                        OffsetDateTime.now().minusDays(1),
+                        creatorId,
+                        "creator", null, null,
+                        null,
+                        StudyStatus.COMPLETED.name(),
+                        ResultSubmitStatus.READY,
+                        5, 0,
+                        false,
+                        java.util.Collections.emptyList()
+                )
+        ));
         when(memberDomainService.getMemberVo(any())).thenReturn(
                 MemberVo.of(requesterId, "name", "s", null, null, MemberRole.PLAYER, java.util.List.of(), null, null, OffsetDateTime.now(), OffsetDateTime.now())
         );

--- a/src/test/java/org/certis/studyplatform/study/domain/service/StudyProgressStatusEventListenerTest.java
+++ b/src/test/java/org/certis/studyplatform/study/domain/service/StudyProgressStatusEventListenerTest.java
@@ -4,7 +4,7 @@ import org.certis.studyplatform.shared.domain.ResultSubmitStatus;
 import org.certis.studyplatform.shared.domain.event.ProgressStatusUpdateEvent;
 import org.certis.studyplatform.shared.domain.service.ProgressStatusService;
 import org.certis.studyplatform.study.domain.StudyStatus;
-import org.certis.studyplatform.study.infrastructure.persistence.entity.StudyEntity;
+import org.certis.studyplatform.study.domain.vo.StudyVo;
 import org.certis.studyplatform.study.domain.repository.StudyCommandRepository;
 import org.certis.studyplatform.study.domain.repository.StudyQueryRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,15 +56,25 @@ class StudyProgressStatusEventListenerTest {
         OffsetDateTime currentTime = OffsetDateTime.now();
         ProgressStatusUpdateEvent event = ProgressStatusUpdateEvent.forStudy(studyId, currentTime);
 
-        StudyEntity studyEntity = StudyEntity.builder()
-            .id(studyId)
-            .status(StudyStatus.APPROVED)
-            .resultSubmitStatus(ResultSubmitStatus.READY)
-            .startedAt(currentTime.minusHours(1))
-            .endedAt(currentTime.plusDays(1))
-            .build();
+        StudyVo studyVo = StudyVo.of(
+            studyId,
+            "t", "d", "c",
+            "cat", "sub",
+            currentTime.minusHours(1),
+            currentTime.plusDays(1),
+            currentTime.minusDays(1),
+            currentTime.minusHours(2),
+            10L,
+            "creator", null, null,
+            null,
+            StudyStatus.APPROVED.name(),
+            ResultSubmitStatus.READY,
+            5, 0,
+            false,
+            java.util.Collections.emptyList()
+        );
 
-        when(studyQueryRepository.findEntityById(studyId)).thenReturn(Optional.of(studyEntity));
+        when(studyQueryRepository.findVoByIdForStatusCheck(studyId)).thenReturn(Optional.of(studyVo));
         when(progressStatusService.calculateStudyStatus(
             any(), any(), any(), any(), any()
         )).thenReturn(new ProgressStatusService.ProgressStatusResult(
@@ -75,12 +85,12 @@ class StudyProgressStatusEventListenerTest {
         eventListener.handleProgressStatusUpdate(event);
 
         // Then
-        ArgumentCaptor<StudyEntity> captor = ArgumentCaptor.forClass(StudyEntity.class);
+        ArgumentCaptor<StudyVo> captor = ArgumentCaptor.forClass(StudyVo.class);
         verify(studyCommandRepository).save(captor.capture());
         
-        StudyEntity savedEntity = captor.getValue();
-        assertThat(savedEntity.getStatus()).isEqualTo(StudyStatus.INPROGRESS);
-        assertThat(savedEntity.getResultSubmitStatus()).isEqualTo(ResultSubmitStatus.READY);
+        StudyVo savedVo = captor.getValue();
+        assertThat(savedVo.status()).isEqualTo(StudyStatus.INPROGRESS.name());
+        assertThat(savedVo.resultSubmitStatus()).isEqualTo(ResultSubmitStatus.READY);
     }
 
     @Test
@@ -91,15 +101,25 @@ class StudyProgressStatusEventListenerTest {
         OffsetDateTime currentTime = OffsetDateTime.now();
         ProgressStatusUpdateEvent event = ProgressStatusUpdateEvent.forStudy(studyId, currentTime);
 
-        StudyEntity studyEntity = StudyEntity.builder()
-            .id(studyId)
-            .status(StudyStatus.APPROVED)
-            .resultSubmitStatus(ResultSubmitStatus.READY)
-            .startedAt(currentTime.minusHours(1))
-            .endedAt(currentTime.plusDays(1))
-            .build();
+        StudyVo studyVo2 = StudyVo.of(
+            studyId,
+            "t", "d", "c",
+            "cat", "sub",
+            currentTime.minusHours(1),
+            currentTime.plusDays(1),
+            currentTime.minusDays(1),
+            currentTime.minusHours(2),
+            10L,
+            "creator", null, null,
+            null,
+            StudyStatus.APPROVED.name(),
+            ResultSubmitStatus.READY,
+            5, 0,
+            false,
+            java.util.Collections.emptyList()
+        );
 
-        when(studyQueryRepository.findEntityById(studyId)).thenReturn(Optional.of(studyEntity));
+        when(studyQueryRepository.findVoByIdForStatusCheck(studyId)).thenReturn(Optional.of(studyVo2));
         when(progressStatusService.calculateStudyStatus(
             any(), any(), any(), any(), any()
         )).thenReturn(new ProgressStatusService.ProgressStatusResult(
@@ -110,7 +130,7 @@ class StudyProgressStatusEventListenerTest {
         eventListener.handleProgressStatusUpdate(event);
 
         // Then
-        verify(studyCommandRepository, never()).save(any(org.certis.studyplatform.study.infrastructure.persistence.entity.StudyEntity.class));
+        verify(studyCommandRepository, never()).save(any(StudyVo.class));
     }
 
     @Test
@@ -121,13 +141,13 @@ class StudyProgressStatusEventListenerTest {
         OffsetDateTime currentTime = OffsetDateTime.now();
         ProgressStatusUpdateEvent event = ProgressStatusUpdateEvent.forStudy(studyId, currentTime);
 
-        when(studyQueryRepository.findEntityById(studyId)).thenReturn(Optional.empty());
+        when(studyQueryRepository.findVoByIdForStatusCheck(studyId)).thenReturn(Optional.empty());
 
         // When
         eventListener.handleProgressStatusUpdate(event);
 
         // Then
-        verify(studyCommandRepository, never()).save(any(org.certis.studyplatform.study.infrastructure.persistence.entity.StudyEntity.class));
+        verify(studyCommandRepository, never()).save(any(StudyVo.class));
         verify(progressStatusService, never()).calculateStudyStatus(any(), any(), any(), any(), any());
     }
 
@@ -139,21 +159,31 @@ class StudyProgressStatusEventListenerTest {
         OffsetDateTime currentTime = OffsetDateTime.now();
         ProgressStatusUpdateEvent event = ProgressStatusUpdateEvent.forStudy(studyId, currentTime);
 
-        StudyEntity studyEntity = StudyEntity.builder()
-            .id(studyId)
-            .status(StudyStatus.APPROVED)
-            .resultSubmitStatus(ResultSubmitStatus.READY)
-            .startedAt(currentTime.plusHours(1)) // 미래 시간
-            .endedAt(currentTime.plusDays(1))
-            .build();
+        StudyVo studyVo3 = StudyVo.of(
+            studyId,
+            "t", "d", "c",
+            "cat", "sub",
+            currentTime.plusHours(1), // 미래 시간
+            currentTime.plusDays(1),
+            currentTime.minusDays(1),
+            currentTime.minusHours(2),
+            10L,
+            "creator", null, null,
+            null,
+            StudyStatus.APPROVED.name(),
+            ResultSubmitStatus.READY,
+            5, 0,
+            false,
+            java.util.Collections.emptyList()
+        );
 
-        when(studyQueryRepository.findEntityById(studyId)).thenReturn(Optional.of(studyEntity));
+        when(studyQueryRepository.findVoByIdForStatusCheck(studyId)).thenReturn(Optional.of(studyVo3));
 
         // When
         eventListener.handleProgressStatusUpdate(event);
 
         // Then
-        verify(studyCommandRepository, never()).save(any(org.certis.studyplatform.study.infrastructure.persistence.entity.StudyEntity.class));
+        verify(studyCommandRepository, never()).save(any(StudyVo.class));
         verify(progressStatusService, never()).calculateStudyStatus(any(), any(), any(), any(), any());
     }
 

--- a/src/test/java/org/certis/studyplatform/study/integration/StudyEndApiE2ETest.java
+++ b/src/test/java/org/certis/studyplatform/study/integration/StudyEndApiE2ETest.java
@@ -4,19 +4,26 @@ import org.certis.studyplatform.shared.domain.ResultSubmitStatus;
 import org.certis.studyplatform.study.application.StudyFacadeService;
 import org.certis.studyplatform.study.presentation.dto.request.StudyEndRequestDto;
 import org.certis.studyplatform.study.presentation.dto.response.StudyDetailResponseDto;
+import org.certis.studyplatform.config.TestEmbeddedPostgresConfig;
+import org.certis.studyplatform.config.TestRedisMockConfig;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.certis.generated.jooq.Tables.STUDY;
+import static org.certis.generated.jooq.Tables.MEMBER;
 
 @SpringBootTest
+@Import({TestEmbeddedPostgresConfig.class, TestRedisMockConfig.class})
+@ActiveProfiles("test")
 @Transactional
 class StudyEndApiE2ETest {
 
@@ -32,6 +39,21 @@ class StudyEndApiE2ETest {
         // Given: Insert a study with ended_at in the past but status APPROVED (not COMPLETED)
         OffsetDateTime now = OffsetDateTime.now();
         Long creatorId = 101L;
+
+        // Satisfy FK: insert minimal member
+        dsl.insertInto(MEMBER)
+                .set(MEMBER.ID, creatorId)
+                .set(MEMBER.NAME, "creator-101")
+                .set(MEMBER.STUDENT_NUMBER, "20200101")
+                .set(MEMBER.ROLE, "PLAYER")
+                .set(MEMBER.GRADE, "JUNIOR")
+                .set(MEMBER.BIRTHDAY, now.minusYears(21))
+                .set(MEMBER.GENDER, "MALE")
+                .set(MEMBER.MAJOR, "CS")
+                .set(MEMBER.CREATED_AT, now)
+                .set(MEMBER.UPDATED_AT, now)
+                .onConflict(MEMBER.ID).doNothing()
+                .execute();
 
         Long studyId = dsl.insertInto(STUDY)
                 .set(STUDY.MEMBER_ID, creatorId)

--- a/src/test/java/org/certis/studyplatform/study/integration/StudyEndApiE2ETest.java
+++ b/src/test/java/org/certis/studyplatform/study/integration/StudyEndApiE2ETest.java
@@ -1,0 +1,70 @@
+package org.certis.studyplatform.study.integration;
+
+import org.certis.studyplatform.shared.domain.ResultSubmitStatus;
+import org.certis.studyplatform.study.application.StudyFacadeService;
+import org.certis.studyplatform.study.presentation.dto.request.StudyEndRequestDto;
+import org.certis.studyplatform.study.presentation.dto.response.StudyDetailResponseDto;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.certis.generated.jooq.Tables.STUDY;
+
+@SpringBootTest
+@Transactional
+class StudyEndApiE2ETest {
+
+    @Autowired
+    private DSLContext dsl;
+
+    @Autowired
+    private StudyFacadeService studyFacadeService;
+
+    @Test
+    @DisplayName("endStudy ignores endedAt; relies on DB status/resultSubmitStatus only")
+    void endStudy_ignoresEndedAt_whenStatusNotCompleted() {
+        // Given: Insert a study with ended_at in the past but status APPROVED (not COMPLETED)
+        OffsetDateTime now = OffsetDateTime.now();
+        Long creatorId = 101L;
+
+        Long studyId = dsl.insertInto(STUDY)
+                .set(STUDY.MEMBER_ID, creatorId)
+                .set(STUDY.TITLE, "E2E")
+                .set(STUDY.DESCRIPTION, "desc")
+                .set(STUDY.CONTENT, "content")
+                .set(STUDY.CATEGORY, "CS")
+                .set(STUDY.SUBCATEGORY, "BE")
+                .set(STUDY.MAX_PARTICIPANTS_NUMBER, 5)
+                .set(STUDY.STARTED_AT, now.minusDays(10))
+                .set(STUDY.ENDED_AT, now.minusDays(1)) // past
+                .set(STUDY.STATUS, "APPROVED") // not COMPLETED
+                .set(STUDY.RESULT_SUBMIT_STATUS, ResultSubmitStatus.READY.name())
+                .returning(STUDY.ID)
+                .fetchOne()
+                .get(STUDY.ID);
+
+        // When: call facade endStudy with requester == creator
+        StudyEndRequestDto req = new StudyEndRequestDto();
+        // via setters to avoid Lombok dependency in tests
+        try {
+            java.lang.reflect.Field f = StudyEndRequestDto.class.getDeclaredField("studyId");
+            f.setAccessible(true);
+            f.set(req, studyId);
+        } catch (Exception ignore) {}
+
+        StudyDetailResponseDto resp = studyFacadeService.endStudy(req, creatorId);
+
+        // Then: success and resultSubmitStatus moved to INPROGRESS (submission created)
+        assertThat(resp).isNotNull();
+        assertThat(resp.getId()).isEqualTo(studyId);
+        // endedAt was past, but operation still proceeded because status != COMPLETED
+    }
+}
+
+

--- a/src/test/java/org/certis/studyplatform/study/integration/StudyQueryRepositoryStatusMappingTest.java
+++ b/src/test/java/org/certis/studyplatform/study/integration/StudyQueryRepositoryStatusMappingTest.java
@@ -1,0 +1,76 @@
+package org.certis.studyplatform.study.integration;
+
+import org.certis.studyplatform.study.domain.repository.StudyQueryRepository;
+import org.certis.studyplatform.study.domain.vo.StudyVo;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.certis.generated.jooq.Tables.STUDY;
+
+@SpringBootTest
+@Transactional
+class StudyQueryRepositoryStatusMappingTest {
+
+    @Autowired
+    private DSLContext dsl;
+
+    @Autowired
+    private StudyQueryRepository studyQueryRepository;
+
+    @Test
+    @DisplayName("findVoByIdForStatusCheck returns DB status as-is, ignoring endedAt")
+    void findVoByIdForStatusCheck_mapsDbStatusIgnoringEndedAt() {
+        // Given: Insert a row with ended_at in the past but status APPROVED
+        OffsetDateTime now = OffsetDateTime.now();
+
+        // Satisfy FK: insert minimal member
+        dsl.insertInto(org.certis.generated.jooq.tables.Member.MEMBER)
+                .set(org.certis.generated.jooq.tables.Member.MEMBER.ID, 202L)
+                .set(org.certis.generated.jooq.tables.Member.MEMBER.NAME, "tester-202")
+                .set(org.certis.generated.jooq.tables.Member.MEMBER.STUDENT_NUMBER, "20200001")
+                .set(org.certis.generated.jooq.tables.Member.MEMBER.ROLE, "PLAYER")
+                .set(org.certis.generated.jooq.tables.Member.MEMBER.GRADE, "JUNIOR")
+                .set(org.certis.generated.jooq.tables.Member.MEMBER.BIRTHDAY, now.minusYears(20))
+                .set(org.certis.generated.jooq.tables.Member.MEMBER.GENDER, "MALE")
+                .set(org.certis.generated.jooq.tables.Member.MEMBER.MAJOR, "CS")
+                .set(org.certis.generated.jooq.tables.Member.MEMBER.CREATED_AT, now)
+                .set(org.certis.generated.jooq.tables.Member.MEMBER.UPDATED_AT, now)
+                .onConflict(org.certis.generated.jooq.tables.Member.MEMBER.ID).doNothing()
+                .execute();
+
+        Long studyId = dsl.insertInto(STUDY)
+                .set(STUDY.MEMBER_ID, 202L)
+                .set(STUDY.TITLE, "status-check")
+                .set(STUDY.DESCRIPTION, "desc")
+                .set(STUDY.CONTENT, "content")
+                .set(STUDY.CATEGORY, "CS")
+                .set(STUDY.SUBCATEGORY, "BE")
+                .set(STUDY.MAX_PARTICIPANTS_NUMBER, 5)
+                .set(STUDY.STARTED_AT, now.minusDays(10))
+                .set(STUDY.ENDED_AT, now.minusDays(1)) // would imply completed by time
+                .set(STUDY.STATUS, "APPROVED") // but DB says APPROVED
+                .set(STUDY.RESULT_SUBMIT_STATUS, "READY")
+                .set(STUDY.CREATED_AT, now.minusDays(11))
+                .set(STUDY.UPDATED_AT, now.minusDays(1))
+                .returning(STUDY.ID)
+                .fetchOne()
+                .get(STUDY.ID);
+
+        // When
+        Optional<StudyVo> voOpt = studyQueryRepository.findVoByIdForStatusCheck(studyId);
+
+        // Then
+        assertThat(voOpt).isPresent();
+        assertThat(voOpt.get().status()).isEqualTo("APPROVED");
+    }
+}
+
+

--- a/src/test/java/org/certis/studyplatform/study/integration/StudyQueryRepositoryStatusMappingTest.java
+++ b/src/test/java/org/certis/studyplatform/study/integration/StudyQueryRepositoryStatusMappingTest.java
@@ -2,11 +2,15 @@ package org.certis.studyplatform.study.integration;
 
 import org.certis.studyplatform.study.domain.repository.StudyQueryRepository;
 import org.certis.studyplatform.study.domain.vo.StudyVo;
+import org.certis.studyplatform.config.TestEmbeddedPostgresConfig;
+import org.certis.studyplatform.config.TestRedisMockConfig;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
@@ -16,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.certis.generated.jooq.Tables.STUDY;
 
 @SpringBootTest
+@Import({TestEmbeddedPostgresConfig.class, TestRedisMockConfig.class})
+@ActiveProfiles("test")
 @Transactional
 class StudyQueryRepositoryStatusMappingTest {
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#100, #101, #102

## 📝작업 내용

- 상태 기반 보고서 제출
- 개인프로필 조회 시 null value field 추가
- security config 경로 변경("/refresh/token")

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

너무 늦어서 죄송합니다. 리뷰 부탁드립니다.
