### PR TITLE
Bucket4j를 이용한 과도한 RefreshToken 발행 요청 제한

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,10 +68,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'redis.clients:jedis'
-    implementation('org.redisson:redisson-spring-boot-starter:3.37.0') {
+    implementation('org.redisson:redisson-spring-boot-starter:3.35.0') {
         exclude group: 'commons-logging'
     }
     implementation 'it.ozimov:embedded-redis:0.7.3'
+
+    // ✅ Bucket4j - Rate Limiting
+    implementation 'com.bucket4j:bucket4j_jdk17-core:8.12.1'
+    implementation 'com.bucket4j:bucket4j_jdk17-redis-common:8.12.1'
+    implementation 'com.bucket4j:bucket4j_jdk17-redisson:8.12.1'
 
     // ✅ jOOQ (CQRS Query Side)
     implementation 'org.springframework.boot:spring-boot-starter-jooq'
@@ -146,11 +151,6 @@ test {
     testLogging {
         events "passed", "skipped", "failed"
     }
-    
-    // Mockito agent configuration to avoid self-attaching warning
-    jvmArgs = [
-        '-javaagent:' + configurations.testRuntimeClasspath.find { it.name.contains('byte-buddy-agent') }.absolutePath
-    ]
 }
 
 // ===================================================================

--- a/src/main/java/org/certis/studyplatform/exception/ExceptionStatus.java
+++ b/src/main/java/org/certis/studyplatform/exception/ExceptionStatus.java
@@ -60,6 +60,7 @@ public enum ExceptionStatus {
 
     // Auth - Presentation Layer
     AUTH_PRESENTATION_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "인증 요청 데이터가 유효하지 않습니다"),
+    AUTH_PRESENTATION_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "토큰 갱신 요청 횟수가 제한을 초과했습니다"),
 
     // Auth - Domain Layer
     AUTH_DOMAIN_JWT_TOKEN_PARSE_ERROR(HttpStatus.BAD_REQUEST, "JWT 토큰 파싱 중 오류가 발생했습니다"),

--- a/src/main/java/org/certis/studyplatform/shared/config/Bucket4jConfig.java
+++ b/src/main/java/org/certis/studyplatform/shared/config/Bucket4jConfig.java
@@ -1,0 +1,47 @@
+package org.certis.studyplatform.shared.config;
+
+import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import io.github.bucket4j.redis.redisson.cas.RedissonBasedProxyManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * Bucket4j Rate Limiting 설정
+ * - Redis를 백엔드로 사용하는 분산 Rate Limiting 구성
+ * - Redisson 클라이언트를 사용하여 Redis 연결
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class Bucket4jConfig {
+
+    private final RedissonClient redissonClient;
+
+    /**
+     * Bucket4j ProxyManager 생성
+     * - Redis 기반 분산 Rate Limiting을 위한 핵심 컴포넌트
+     * - 버킷은 Redis에 저장되어 여러 서버 인스턴스 간 공유됨
+     */
+    @Bean
+    public ProxyManager<String> bucket4jProxyManager() {
+        log.info("Initializing Bucket4j ProxyManager with Redisson backend");
+
+        // RedissonClient를 Redisson으로 캐스팅하여 CommandExecutor 가져오기
+        Redisson redisson = (Redisson) redissonClient;
+
+        return RedissonBasedProxyManager.builderFor(redisson.getCommandExecutor())
+                .withExpirationStrategy(
+                        ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(
+                                Duration.ofMinutes(5) // 버킷이 사용되지 않으면 5분 후 Redis에서 자동 삭제
+                        )
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/certis/studyplatform/shared/config/SecurityConfig.java
+++ b/src/main/java/org/certis/studyplatform/shared/config/SecurityConfig.java
@@ -1,9 +1,9 @@
 package org.certis.studyplatform.shared.config;
 
 import lombok.RequiredArgsConstructor;
-// import org.certis.studyplatform.shared.security.JwtAuthenticationFilter;  // 🔥 JWT 비활성화
-// import org.certis.studyplatform.shared.security.JwtTokenProvider;        // 🔥 JWT 비활성화
 import org.certis.studyplatform.shared.security.JwtAuthenticationFilter;
+import org.certis.studyplatform.shared.security.JwtTokenProvider;
+import org.certis.studyplatform.shared.security.RateLimitingFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -21,16 +21,20 @@ import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity(prePostEnabled = true) // @PreAuthorize 활성화
+@EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
-@Profile("!test") // 테스트 환경이 아닐 때만 활성화
+@Profile("!test")
 public class SecurityConfig {
 
     private final CorsConfigurationSource corsConfigurationSource;
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RateLimitingFilter rateLimitingFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        // JWT 필터 인스턴스 생성
+        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenProvider);
+
         http
                 // CORS 설정 적용
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
@@ -39,10 +43,6 @@ public class SecurityConfig {
                 // 세션 사용하지 않음 (JWT는 Stateless)
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                )
-                // H2 Console을 위한 설정 (개발환경용)
-                .headers(headers ->
-                        headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
                 )
                 // 경로별 권한 설정
                 .authorizeHttpRequests(auths -> auths
@@ -53,13 +53,12 @@ public class SecurityConfig {
                                 "/api/v1/member/**",
                                 "/api/v1/auth/login",
                                 "/api/v1/auth/logout",
-                                "/api/v1/auth/register",  // 회원가입 추가
-                                "/api/v1/auth/token/refresh",   // 토큰 갱신
-                                "/api/v1/blog",              // 블로그 목록 조회
-                                "/api/v1/blog/detail",       // 블로그 상세 조회
-                                "/api/v1/blog/search",       // 블로그 검색
-                                "/api/v1/blog/search/keyword", // 블로그 고급 검색
-                
+                                "/api/v1/auth/register",
+                                "/api/v1/auth/token/refresh",
+                                "/api/v1/blog",
+                                "/api/v1/blog/detail",
+                                "/api/v1/blog/search",
+                                "/api/v1/blog/search/keyword",
                                 
                                 //문서 모니터링
                                 "/api/v1/board",
@@ -97,14 +96,14 @@ public class SecurityConfig {
                                 "/api/v1/study/participant/{studyId}/participants/pending",
                                 "/api/v1/study/participant/{studyId}/participants/approved",
 
-                                // Swagger/OpenAPI 관련 경로 (더 포괄적으로 수정)
-                                "/swagger-ui/**",           // 모든 swagger-ui 하위 경로
+                                // Swagger/OpenAPI 관련 경로
+                                "/swagger-ui/**",
                                 "/swagger-ui.html",
-                                "/v3/api-docs/**",          // 모든 api-docs 하위 경로
-                                "/swagger-resources/**",    // Swagger 리소스
-                                "/webjars/**",             // Swagger UI 웹 자원
-                                "/configuration/ui",        // Swagger UI 설정
-                                "/configuration/security",  // Swagger 보안 설정
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/webjars/**",
+                                "/configuration/ui",
+                                "/configuration/security",
                                 "/v3/api-docs",
                                 "/actuator/health",
                                 "/favicon.ico",
@@ -116,7 +115,9 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
 
-                // JWT 인증 필터 등록
+                // 필터 등록: Rate Limiting 필터를 JWT 필터 앞에 추가
+                .addFilterBefore(rateLimitingFilter, UsernamePasswordAuthenticationFilter.class)
+                // JWT 인증 필터를 UsernamePasswordAuthenticationFilter 앞에 추가
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 
                 // 기본 폼 로그인 비활성화
@@ -129,7 +130,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    @Profile("!test") // 테스트 환경이 아닐 때만 활성화
+    @Profile("!test")
     public PasswordEncoder passwordEncoder(){
         return new BCryptPasswordEncoder();
     }

--- a/src/main/java/org/certis/studyplatform/shared/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/certis/studyplatform/shared/security/JwtAuthenticationFilter.java
@@ -9,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.certis.studyplatform.member.domain.MemberRole;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -20,12 +19,73 @@ import java.util.List;
 
 
 @Slf4j
-@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
+    private static final List<String> EXCLUDED_PATHS = Arrays.asList(
+            // 인증 관련
+            "/api/v1/member/**",
+            "/api/v1/auth/login",
+            "/api/v1/auth/register",  // 회원가입 추가
+            "/api/v1/auth/token/refresh",   // 토큰 갱신
+            "/api/v1/blog",              // 블로그 목록 조회
+            "/api/v1/blog/detail",       // 블로그 상세 조회
+            "/api/v1/blog/search",       // 블로그 검색
+            "/api/v1/blog/search/keyword", // 블로그 고급 검색
+
+
+            //문서 모니터링
+            "/api/v1/board",
+            "/api/v1/board/search/**",
+            "/api/v1/board/search",
+            "/api/v1/board/detail",
+
+            "/api/v1/project/search",
+            "/api/v1/project/detail",
+            "/api/v1/project/search/**",
+            "/api/v1/project",
+            "/api/v1/project/{projectId}/meetings",
+            "/api/v1/project/meeting/detail",
+            "/api/v1/project/meeting/all",
+            "/api/v1/project/participant/{projectId}/participants/{participantId}",
+            "/api/v1/project/participant/members/{memberId}/participants",
+            "/api/v1/project/participant/{projectId}/participants/all",
+            "/api/v1/project/participant/{projectId}/participants/pending",
+            "/api/v1/project/participant/{projectId}/participants/approved",
+            "/api/v1/project/participant/{projectId}/participants/pending/**",
+            "/api/v1/project/participant/{projectId}/participants/approved/**",
+
+            "/api/v1/schedule/requests",
+            "/api/v1/schedule/requests/**",
+
+            "/api/v1/study/search",
+            "/api/v1/study/detail",
+            "/api/v1/study/search/**",
+            "/api/v1/study",
+            "/api/v1/study/{studyId}/meetings",
+            "/api/v1/study/meeting/detail",
+            "/api/v1/study/meeting/all",
+            "/api/v1/study/participant/{studyId}/participants/{participantId}",
+            "/api/v1/study/participant/members/{memberId}/participants",
+            "/api/v1/study/participant/{studyId}/participants/pending",
+            "/api/v1/study/participant/{studyId}/participants/approved",
+            "/api/v1/study/participant/{studyId}/participants/pending/**",
+            "/api/v1/study/participant/{studyId}/participants/approved/**",
+
+            // Swagger/OpenAPI 관련 경로 (더 포괄적으로 수정)
+            "/swagger-ui/**",           // 모든 swagger-ui 하위 경로
+            "/swagger-ui.html",
+            "/v3/api-docs/**",          // 모든 api-docs 하위 경로
+            "/swagger-resources/**",    // Swagger 리소스
+            "/webjars/**",             // Swagger UI 웹 자원
+            "/configuration/ui",        // Swagger UI 설정
+            "/configuration/security",  // Swagger 보안 설정
+            "/actuator/health",
+            "/favicon.ico",
+            "/error"
+    );
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -115,74 +175,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (isInvalidApiPath(requestURI)) {
             return true; // 잘못된 경로는 필터를 건너뛰어 404 처리되도록 함
         }
-        
-        final List<String> excludedPaths = Arrays.asList(
-                // 인증 관련
-                "/api/v1/member/**",
-                "/api/v1/auth/login",
-                "/api/v1/auth/register",  // 회원가입 추가
-                "/api/v1/auth/token/refresh",   // 토큰 갱신
-                "/api/v1/blog",              // 블로그 목록 조회
-                "/api/v1/blog/detail",       // 블로그 상세 조회
-                "/api/v1/blog/search",       // 블로그 검색
-                "/api/v1/blog/search/keyword", // 블로그 고급 검색
 
-                
-                //문서 모니터링
-                "/api/v1/board",
-                "/api/v1/board/search/**",
-                "/api/v1/board/search",
-                "/api/v1/board/detail",
-
-                "/api/v1/project/search",
-                "/api/v1/project/detail",
-                "/api/v1/project/search/**",
-                "/api/v1/project",
-                "/api/v1/project/{projectId}/meetings",
-                "/api/v1/project/meeting/detail",
-                "/api/v1/project/meeting/all",
-                "/api/v1/project/participant/{projectId}/participants/{participantId}",
-                "/api/v1/project/participant/members/{memberId}/participants",
-                "/api/v1/project/participant/{projectId}/participants/all",
-                "/api/v1/project/participant/{projectId}/participants/pending",
-                "/api/v1/project/participant/{projectId}/participants/approved",
-                "/api/v1/project/participant/{projectId}/participants/pending/**",
-                "/api/v1/project/participant/{projectId}/participants/approved/**",
-
-                "/api/v1/schedule/requests",
-                "/api/v1/schedule/requests/**",
-
-                "/api/v1/study/search",
-                "/api/v1/study/detail",
-                "/api/v1/study/search/**",
-                "/api/v1/study",
-                "/api/v1/study/{studyId}/meetings",
-                "/api/v1/study/meeting/detail",
-                "/api/v1/study/meeting/all",
-                "/api/v1/study/participant/{studyId}/participants/{participantId}",
-                "/api/v1/study/participant/members/{memberId}/participants",
-                "/api/v1/study/participant/{studyId}/participants/pending",
-                "/api/v1/study/participant/{studyId}/participants/approved",
-                "/api/v1/study/participant/{studyId}/participants/pending/**",
-                "/api/v1/study/participant/{studyId}/participants/approved/**",
-
-                // Swagger/OpenAPI 관련 경로 (더 포괄적으로 수정)
-                "/swagger-ui/**",           // 모든 swagger-ui 하위 경로
-                "/swagger-ui.html",
-                "/v3/api-docs/**",          // 모든 api-docs 하위 경로
-                "/swagger-resources/**",    // Swagger 리소스
-                "/webjars/**",             // Swagger UI 웹 자원
-                "/configuration/ui",        // Swagger UI 설정
-                "/configuration/security",  // Swagger 보안 설정
-                "/actuator/health",
-                "/favicon.ico",
-                "/error"
-        );
-
-        String path = request.getRequestURI();
-
-        return excludedPaths.stream()
-                .anyMatch(pattern -> pathMatcher.match(pattern, path));
+        return EXCLUDED_PATHS.stream()
+                .anyMatch(pattern -> pathMatcher.match(pattern, requestURI));
     }
     
     /**

--- a/src/main/java/org/certis/studyplatform/shared/security/RateLimitingFilter.java
+++ b/src/main/java/org/certis/studyplatform/shared/security/RateLimitingFilter.java
@@ -1,0 +1,103 @@
+package org.certis.studyplatform.shared.security;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.certis.studyplatform.exception.ExceptionStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.function.Supplier;
+
+/**
+ * Bucket4j 기반 Rate Limiting 필터
+ * - RefreshToken 엔드포인트에 대한 요청 속도를 제한합니다.
+ * - IP 주소당 1분에 10회로 제한됩니다.
+ * - 제한 초과 시 HTTP 429 (Too Many Requests) 응답을 반환합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RateLimitingFilter extends OncePerRequestFilter {
+
+    private final ProxyManager<String> proxyManager;
+
+    // Rate Limiting 설정: 1분당 10회 요청 허용
+    private static final int REQUEST_LIMIT = 10;
+    private static final Duration REFILL_DURATION = Duration.ofMinutes(1);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        // /api/v1/auth/token/refresh 경로만 rate limiting 적용
+        String requestURI = request.getRequestURI();
+        if (!requestURI.equals("/api/v1/auth/token/refresh")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // IP 주소 기반으로 버킷 키 생성
+        String clientIp = getClientIp(request);
+        String bucketKey = "rate_limit:refresh_token:" + clientIp;
+
+        // Bucket 가져오기 또는 생성
+        Bucket bucket = proxyManager.builder().build(bucketKey, getConfigurationSupplier());
+
+        // 토큰 소비 시도
+        if (bucket.tryConsume(1)) {
+            // 요청 허용
+            filterChain.doFilter(request, response);
+        } else {
+            // Rate limit 초과 - 429 응답
+            log.warn("Rate limit exceeded for IP: {}, endpoint: {}", clientIp, requestURI);
+            response.setStatus(ExceptionStatus.AUTH_PRESENTATION_RATE_LIMIT_EXCEEDED.getStatusCode());
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write(String.format(
+                "{\"statusCode\":%d,\"message\":\"%s\"}",
+                ExceptionStatus.AUTH_PRESENTATION_RATE_LIMIT_EXCEEDED.getStatusCode(),
+                ExceptionStatus.AUTH_PRESENTATION_RATE_LIMIT_EXCEEDED.getMessage()
+            ));
+        }
+    }
+
+    /**
+     * Bucket4j 설정을 반환하는 Supplier
+     * - 1분당 10회 요청 허용 (Token Bucket 알고리즘)
+     */
+    private Supplier<BucketConfiguration> getConfigurationSupplier() {
+        return () -> {
+            Bandwidth limit = Bandwidth.builder()
+                    .capacity(REQUEST_LIMIT)
+                    .refillIntervally(REQUEST_LIMIT, REFILL_DURATION)
+                    .build();
+            return BucketConfiguration.builder()
+                    .addLimit(limit)
+                    .build();
+        };
+    }
+
+    /**
+     * 클라이언트 IP 주소 추출
+     * - X-Forwarded-For 헤더를 우선 확인 (프록시 환경 대응)
+     * - 없으면 RemoteAddr 사용
+     */
+    private String getClientIp(HttpServletRequest request) {
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (xForwardedFor != null && !xForwardedFor.isEmpty()) {
+            // X-Forwarded-For는 쉼표로 구분된 IP 목록일 수 있으므로 첫 번째 IP 사용
+            return xForwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/test/java/org/certis/studyplatform/config/EmbeddedRedisConfig.java
+++ b/src/test/java/org/certis/studyplatform/config/EmbeddedRedisConfig.java
@@ -1,0 +1,81 @@
+package org.certis.studyplatform.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Profile;
+import redis.embedded.RedisServer;
+
+import java.io.IOException;
+
+/**
+ * 통합 테스트용 Embedded Redis 설정
+ * 실제 Redis 서버 없이 메모리 내에서 Redis 동작
+ */
+@Slf4j
+@TestConfiguration
+@Profile("redis-test") // redis-test 프로필에서만 활성화
+public class EmbeddedRedisConfig {
+
+    private RedisServer redisServer;
+
+    @Value("${spring.data.redis.port:6379}")
+    private int redisPort;
+
+    @PostConstruct
+    public void startRedis() throws IOException {
+        int port = isRedisRunning() ? findAvailablePort() : redisPort;
+        
+        // ARM Mac 등 환경 호환성을 위해 maxheap 설정이 필요할 수 있음
+        try {
+            redisServer = RedisServer.builder()
+                    .port(port)
+                    .setting("maxmemory 128M") // 메모리 제한 설정
+                    .build();
+            
+            redisServer.start();
+            log.info("Embedded Redis started on port {}", port);
+            
+            // 동적으로 할당된 포트를 시스템 프로퍼티에 설정 (application-redis-test.yml에서 참조 가능)
+            System.setProperty("embedded.redis.actual.port", String.valueOf(port));
+            
+        } catch (Exception e) {
+            log.error("Embedded Redis start failed", e);
+            // 이미 실행 중인 경우 무시하거나 재시도 하는 등의 로직이 필요할 수 있음
+        }
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        if (redisServer != null) {
+            redisServer.stop();
+            log.info("Embedded Redis stopped");
+        }
+    }
+
+    /**
+     * 현재 설정된 포트가 사용 중인지 확인
+     */
+    private boolean isRedisRunning() throws IOException {
+        return isPortRunning(redisPort);
+    }
+
+    private boolean isPortRunning(int port) throws IOException {
+        try (java.net.Socket ignored = new java.net.Socket("localhost", port)) {
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     * 사용 가능한 랜덤 포트 찾기
+     */
+    private int findAvailablePort() throws IOException {
+        try (java.net.ServerSocket serverSocket = new java.net.ServerSocket(0)) {
+            return serverSocket.getLocalPort();
+        }
+    }
+}

--- a/src/test/java/org/certis/studyplatform/shared/security/RateLimitingFilterTest.java
+++ b/src/test/java/org/certis/studyplatform/shared/security/RateLimitingFilterTest.java
@@ -1,0 +1,124 @@
+package org.certis.studyplatform.shared.security;
+
+import io.github.bucket4j.distributed.BucketProxy;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import io.github.bucket4j.distributed.proxy.RemoteBucketBuilder;
+import jakarta.servlet.FilterChain;
+import org.certis.studyplatform.exception.ExceptionStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RateLimitingFilterTest {
+
+    @Mock
+    private ProxyManager<String> proxyManager;
+
+    @Mock
+    private RemoteBucketBuilder<String> bucketBuilder;
+
+    @Mock
+    private BucketProxy bucket;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @InjectMocks
+    private RateLimitingFilter rateLimitingFilter;
+
+    @Test
+    @DisplayName("RefreshToken 엔드포인트가 아니면 Rate Limiting을 건너뛴다")
+    void shouldSkipRateLimitingForNonRefreshEndpoint() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/api/v1/auth/login");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        rateLimitingFilter.doFilter(request, response, filterChain);
+
+        // then
+        verify(filterChain).doFilter(request, response);
+        verify(proxyManager, never()).builder();
+    }
+
+    @Test
+    @DisplayName("Rate Limit 내의 요청은 성공적으로 통과한다")
+    void shouldAllowRequestWithinRateLimit() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/api/v1/auth/token/refresh");
+        request.setRemoteAddr("127.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        given(proxyManager.builder()).willReturn(bucketBuilder);
+        // any(Supplier.class)를 사용하여 모호성 해결
+        given(bucketBuilder.build(anyString(), any(Supplier.class))).willReturn(bucket);
+        given(bucket.tryConsume(1)).willReturn(true);
+
+        // when
+        rateLimitingFilter.doFilter(request, response, filterChain);
+
+        // then
+        verify(filterChain).doFilter(request, response);
+        verify(bucket).tryConsume(1);
+    }
+
+    @Test
+    @DisplayName("Rate Limit 초과 시 429 에러를 반환한다")
+    void shouldRejectRequestExceedingRateLimit() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/api/v1/auth/token/refresh");
+        request.setRemoteAddr("127.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        given(proxyManager.builder()).willReturn(bucketBuilder);
+        given(bucketBuilder.build(anyString(), any(Supplier.class))).willReturn(bucket);
+        given(bucket.tryConsume(1)).willReturn(false);
+
+        // when
+        rateLimitingFilter.doFilter(request, response, filterChain);
+
+        // then
+        verify(filterChain, never()).doFilter(request, response);
+        
+        assertThat(response.getStatus()).isEqualTo(ExceptionStatus.AUTH_PRESENTATION_RATE_LIMIT_EXCEEDED.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("X-Forwarded-For 헤더가 있을 경우 이를 사용하여 IP를 식별한다")
+    void shouldUseXForwardedForHeader() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/api/v1/auth/token/refresh");
+        request.addHeader("X-Forwarded-For", "10.0.0.1, 192.168.1.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        given(proxyManager.builder()).willReturn(bucketBuilder);
+        given(bucketBuilder.build(eq("rate_limit:refresh_token:10.0.0.1"), any(Supplier.class))).willReturn(bucket);
+        given(bucket.tryConsume(1)).willReturn(true);
+
+        // when
+        rateLimitingFilter.doFilter(request, response, filterChain);
+
+        // then
+        verify(filterChain).doFilter(request, response);
+        verify(bucket).tryConsume(1);
+    }
+}

--- a/src/test/java/org/certis/studyplatform/shared/security/RateLimitingIntegrationTest.java
+++ b/src/test/java/org/certis/studyplatform/shared/security/RateLimitingIntegrationTest.java
@@ -1,0 +1,78 @@
+package org.certis.studyplatform.shared.security;
+
+import org.certis.studyplatform.config.EmbeddedRedisConfig;
+import org.certis.studyplatform.config.TestEmbeddedPostgresConfig;
+import org.certis.studyplatform.exception.ExceptionStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Rate Limiting 통합 테스트
+ * - 실제 Embedded Redis를 구동하여 Redisson 및 Bucket4j 동작 확인
+ * - redis-test 프로필 사용 (TestRedisMockConfig 비활성화)
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("redis-test") // 중요: test 프로필 대신 redis-test 사용
+@Import({EmbeddedRedisConfig.class, TestEmbeddedPostgresConfig.class}) // Embedded Redis 및 DB 설정 로드
+class RateLimitingIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("Rate Limit 통합 테스트: 10회 허용 후 11회째 차단")
+    void shouldRateLimitRealRedis() throws Exception {
+        String endpoint = "/api/v1/auth/token/refresh";
+
+        // 1. 10회 요청은 성공 (또는 인증 오류 등 Rate Limit 관련 오류가 아님)
+        for (int i = 0; i < 10; i++) {
+            int currentRequestIndex = i;
+            mockMvc.perform(post(endpoint)
+                            .header("X-Forwarded-For", "127.0.0.1")) // IP 기반 제한이므로 IP 고정
+                    .andExpect(result -> {
+                        // 429가 아니면 통과한 것으로 간주
+                        if (result.getResponse().getStatus() == ExceptionStatus.AUTH_PRESENTATION_RATE_LIMIT_EXCEEDED.getStatusCode()) {
+                            throw new AssertionError("Rate limit exceeded prematurely at request " + (currentRequestIndex + 1));
+                        }
+                    });
+        }
+
+        // 2. 11번째 요청은 429 Too Many Requests 발생해야 함
+        mockMvc.perform(post(endpoint)
+                        .header("X-Forwarded-For", "127.0.0.1"))
+                .andExpect(status().is(ExceptionStatus.AUTH_PRESENTATION_RATE_LIMIT_EXCEEDED.getStatusCode()));
+    }
+    
+    @Test
+    @DisplayName("다른 IP는 별도의 Limit을 가진다")
+    void shouldSeparateLimitByIp() throws Exception {
+        String endpoint = "/api/v1/auth/token/refresh";
+
+        // IP 1: 5회 요청
+        for (int i = 0; i < 5; i++) {
+            mockMvc.perform(post(endpoint)
+                    .header("X-Forwarded-For", "10.0.0.1"));
+        }
+        
+        // IP 2: 5회 요청 (IP 1의 영향 없어야 함)
+        for (int i = 0; i < 5; i++) {
+            mockMvc.perform(post(endpoint)
+                            .header("X-Forwarded-For", "10.0.0.2"))
+                    .andExpect(result -> {
+                        if (result.getResponse().getStatus() == ExceptionStatus.AUTH_PRESENTATION_RATE_LIMIT_EXCEEDED.getStatusCode()) {
+                            throw new AssertionError("Rate limit affected by other IP");
+                        }
+                    });
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#11 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

로그인 이후 사용자로부터 과도한 RefreshToken 재발급 요청에 대해서 처리하기 위해서

Bucket4j를 이용해서 1분당 요청 10회의 제한을 두어서 처리하고자 합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
