### PR TITLE
Feat: Image upload to S3

### DIFF
--- a/src/main/java/org/certis/studyplatform/exception/ExceptionStatus.java
+++ b/src/main/java/org/certis/studyplatform/exception/ExceptionStatus.java
@@ -398,7 +398,7 @@ public enum ExceptionStatus {
     S3_INFRASTRUCTURE_CONNECTION_FAILED(HttpStatus.BAD_REQUEST, "S3 연결에 실패했습니다"),
     S3_INFRASTRUCTURE_UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "S3 파일 업로드에 실패했습니다"),
     S3_INFRASTRUCTURE_DELETE_FAILED(HttpStatus.BAD_REQUEST, "S3 파일 삭제에 실패했습니다"),
-    S3_INFRASTRUCTURE_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "파일 크기가 제한을 초과했습니다"),
+    S3_INFRASTRUCTURE_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "파일 크기가 제한(10MB)을 초과했습니다"),
     S3_INFRASTRUCTURE_INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다"),
     
     // Project - Application Layer (S3 관련)

--- a/src/main/java/org/certis/studyplatform/file/application/FileUploadFacadeService.java
+++ b/src/main/java/org/certis/studyplatform/file/application/FileUploadFacadeService.java
@@ -1,0 +1,24 @@
+package org.certis.studyplatform.file.application;
+
+import lombok.RequiredArgsConstructor;
+import org.certis.studyplatform.file.application.port.FileStoragePort;
+import org.certis.studyplatform.file.domain.vo.FileVo;
+import org.certis.studyplatform.file.presentation.dto.response.FileUploadResponseDto;
+import org.certis.studyplatform.shared.type.ImageCategory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class FileUploadFacadeService {
+    private final FileStoragePort fileStoragePort;
+
+    public FileUploadResponseDto uploadImage(MultipartFile file, ImageCategory category){
+
+        FileVo fileVo = fileStoragePort.upload(file,category);
+
+        return FileUploadResponseDto.builder()
+                .imageUrl(fileVo.url())
+                .build();
+    }
+}

--- a/src/main/java/org/certis/studyplatform/file/application/port/FileStoragePort.java
+++ b/src/main/java/org/certis/studyplatform/file/application/port/FileStoragePort.java
@@ -1,0 +1,11 @@
+package org.certis.studyplatform.file.application.port;
+
+import org.certis.studyplatform.file.domain.vo.FileVo;
+import org.certis.studyplatform.shared.type.ImageCategory;
+import org.springframework.web.multipart.MultipartFile;
+
+// 별도의 복잡한 비즈니스 로직(도메인 서비스)이 필요하지 않은 단순 파일 전송 기능이므로,
+// 어플리케이션 서비스에서 인프라 포트(Port)를 직접 호출하도록 설계했습니다. 이를 통해 불필요한 레이어 진입을 줄이고 코드의 직관성을 높였습니다.
+public interface FileStoragePort {
+    FileVo upload(MultipartFile file, ImageCategory category);
+}

--- a/src/main/java/org/certis/studyplatform/file/domain/vo/FileVo.java
+++ b/src/main/java/org/certis/studyplatform/file/domain/vo/FileVo.java
@@ -1,0 +1,16 @@
+package org.certis.studyplatform.file.domain.vo;
+
+import lombok.Builder;
+
+@Builder
+public record FileVo(
+        String url,
+        String fileName
+) {
+    public static FileVo of(String url, String fileName) {
+        return FileVo.builder()
+                .url(url)
+                .fileName(fileName)
+                .build();
+    }
+}

--- a/src/main/java/org/certis/studyplatform/file/infrastructure/FileUploadAdapter.java
+++ b/src/main/java/org/certis/studyplatform/file/infrastructure/FileUploadAdapter.java
@@ -1,0 +1,26 @@
+package org.certis.studyplatform.file.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.certis.studyplatform.file.application.port.FileStoragePort;
+import org.certis.studyplatform.file.domain.vo.FileVo;
+import org.certis.studyplatform.shared.service.S3AttachmentService;
+import org.certis.studyplatform.shared.type.ImageCategory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FileUploadAdapter implements FileStoragePort {
+
+    private  final S3AttachmentService s3AttachmentService;
+    @Override
+    public FileVo upload(MultipartFile file, ImageCategory category) {
+        log.info("Infra: Uploading file. Category: {}", category);
+
+        String uploadedUrl = s3AttachmentService.uploadImageByCategory(file, category);
+
+        return FileVo.of(uploadedUrl,file.getOriginalFilename());
+    }
+}

--- a/src/main/java/org/certis/studyplatform/file/presentation/FileUploadController.java
+++ b/src/main/java/org/certis/studyplatform/file/presentation/FileUploadController.java
@@ -1,0 +1,40 @@
+package org.certis.studyplatform.file.presentation;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.certis.studyplatform.file.application.FileUploadFacadeService;
+import org.certis.studyplatform.file.presentation.dto.response.FileUploadResponseDto;
+import org.certis.studyplatform.response.GlobalResponseHandler;
+import org.certis.studyplatform.response.ResponseStatus;
+import org.certis.studyplatform.shared.type.ImageCategory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/files")
+@RequiredArgsConstructor
+@Slf4j
+public class FileUploadController {
+
+    private final FileUploadFacadeService fileUploadFacadeService;
+
+    @PostMapping("/image")
+    public ResponseEntity<GlobalResponseHandler<FileUploadResponseDto>> uploadImage(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("type") String type
+    ) {
+        // 1. Enum 변환
+        ImageCategory category = ImageCategory.from(type);
+
+        // 2. UseCase 호출 (DTO 반환됨)
+        FileUploadResponseDto responseDto = fileUploadFacadeService.uploadImage(file, category);
+
+        // 3. 응답 반환
+        return GlobalResponseHandler.success(ResponseStatus.FILE_UPLOAD_SUCCESS, responseDto);
+    }
+
+}

--- a/src/main/java/org/certis/studyplatform/file/presentation/dto/response/FileUploadResponseDto.java
+++ b/src/main/java/org/certis/studyplatform/file/presentation/dto/response/FileUploadResponseDto.java
@@ -1,0 +1,15 @@
+package org.certis.studyplatform.file.presentation.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FileUploadResponseDto {
+    private String imageUrl;
+}

--- a/src/main/java/org/certis/studyplatform/shared/service/S3AttachmentService.java
+++ b/src/main/java/org/certis/studyplatform/shared/service/S3AttachmentService.java
@@ -3,6 +3,7 @@ package org.certis.studyplatform.shared.service;
 import lombok.extern.slf4j.Slf4j;
 import org.certis.studyplatform.exception.ExceptionStatus;
 import org.certis.studyplatform.exception.InfrastructureException;
+import org.certis.studyplatform.shared.type.ImageCategory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -23,6 +24,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,6 +43,9 @@ public class S3AttachmentService {
 
     @Value("${aws.s3.bucket-name:${AWS_S3_BUCKET:test-bucket}}")
     private String bucketName;
+
+    @Value("${aws.s3.image-bucket-name:${AWS_S3_IMAGE_BUCKET:test-bucket}}")
+    private String imageBucketName;
 
     @Value("${aws.s3.region:${AWS_DEFAULT_REGION:ap-northeast-2}}")
     private String region;
@@ -157,6 +162,7 @@ public class S3AttachmentService {
             throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_UPLOAD_FAILED);
         }
     }
+
 
     /**
      * 파일을 S3에 업로드하고 URL 반환 (커스텀 파일명 사용)
@@ -609,9 +615,8 @@ public class S3AttachmentService {
             
             // 고유한 파일명 생성
             String originalFileName = file.getOriginalFilename();
-            String extension = originalFileName != null && originalFileName.contains(".") 
-                    ? originalFileName.substring(originalFileName.lastIndexOf("."))
-                    : "";
+            String extension =getExtension(originalFileName);
+
             String uniqueFileName = UUID.randomUUID().toString() + extension;
             
             // S3 키 생성 (도메인별로 폴더 구분)
@@ -647,6 +652,47 @@ public class S3AttachmentService {
                     domain, entityId, e.getMessage());
             throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_UPLOAD_FAILED);
         }
+    }
+
+
+    /**
+     * Image 파일을 S3에 업로드하고 URL 반환 (10MB 제한)
+     */
+    public String uploadImageByCategory(MultipartFile file, ImageCategory imageCategory){
+    try {
+
+
+        if (file == null || file.isEmpty()) {
+            throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_INVALID_FILE_TYPE);
+        }
+
+        // 프로필 이미지 파일 크기 제한: 10MB
+        validateFileSize(file, 10);
+
+        // 이미지 파일 타입 검증
+        validateImageFileType(file);
+
+        String datePath = LocalDateTime.now().toString().replace("-", "/");
+
+        String extension = getExtension(file.getOriginalFilename());
+        String uniqueFileName = UUID.randomUUID() + extension;
+
+        String s3Key = String.format("%s/%s/%s", imageCategory.getS3Folder(), datePath, uniqueFileName);
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(imageBucketName)
+                .key(s3Key)
+                .contentType(file.getContentType())
+                .build();
+
+        s3Client.putObject(putObjectRequest, RequestBody.fromBytes(file.getBytes()));
+
+        return buildS3Url(bucketName, region, s3Key);
+
+        }catch (Exception e) {
+        log.error("프로필 이미지 S3 업로드 중 예상치 못한 오류 발생:  error={}", e.getMessage());
+        throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_UPLOAD_FAILED);
+    }
     }
 
     /**
@@ -721,5 +767,11 @@ public class S3AttachmentService {
             // Fallback to raw key if encoding fails (should not happen)
             return "https://" + bucket + ".s3." + regionName + ".amazonaws.com/" + key;
         }
+    }
+
+    private String getExtension(String fileName) {
+        return fileName != null && fileName.contains(".")
+                ? fileName.substring(fileName.lastIndexOf("."))
+                : "";
     }
 }

--- a/src/main/java/org/certis/studyplatform/shared/service/S3AttachmentService.java
+++ b/src/main/java/org/certis/studyplatform/shared/service/S3AttachmentService.java
@@ -691,7 +691,7 @@ public class S3AttachmentService {
 
         }catch (Exception e) {
         log.error("이미지 S3 업로드 중 예상치 못한 오류 발생:  error={}", e.getMessage());
-        throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_UPLOAD_FAILED);
+        throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_UPLOAD_FAILED,e.getMessage());
     }
     }
 

--- a/src/main/java/org/certis/studyplatform/shared/service/S3AttachmentService.java
+++ b/src/main/java/org/certis/studyplatform/shared/service/S3AttachmentService.java
@@ -47,7 +47,7 @@ public class S3AttachmentService {
     @Value("${aws.s3.image-bucket-name:${AWS_S3_IMAGE_BUCKET:test-bucket}}")
     private String imageBucketName;
 
-    @Value("${aws.s3.region:${AWS_DEFAULT_REGION:ap-northeast-2}}")
+    @Value("${aws.s3.region:${AWS_DEFAULT_REGION:ap-southeast-2}}")
     private String region;
 
     @Value("${aws.s3.access-key-id:${AWS_ACCESS_KEY_ID:}}")
@@ -687,10 +687,10 @@ public class S3AttachmentService {
 
         s3Client.putObject(putObjectRequest, RequestBody.fromBytes(file.getBytes()));
 
-        return buildS3Url(bucketName, region, s3Key);
+        return buildS3Url(imageBucketName, region, s3Key);
 
         }catch (Exception e) {
-        log.error("프로필 이미지 S3 업로드 중 예상치 못한 오류 발생:  error={}", e.getMessage());
+        log.error("이미지 S3 업로드 중 예상치 못한 오류 발생:  error={}", e.getMessage());
         throw new InfrastructureException(ExceptionStatus.S3_INFRASTRUCTURE_UPLOAD_FAILED);
     }
     }

--- a/src/main/java/org/certis/studyplatform/shared/type/ImageCategory.java
+++ b/src/main/java/org/certis/studyplatform/shared/type/ImageCategory.java
@@ -1,0 +1,28 @@
+package org.certis.studyplatform.shared.type;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.certis.studyplatform.exception.ExceptionStatus;
+import org.certis.studyplatform.exception.InfrastructureException;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageCategory {
+    BLOG("blog","blog-image"),
+    PROJECT("project","project-image");
+
+    private final String requestType; // 프론트에서 보내는 값
+    private final String s3Folder; // S3에 저장될 폴더 명
+
+    public static ImageCategory from(String type){ // 적절한 타입인지 검증
+        for(ImageCategory category : values()){
+            if(category.requestType.equalsIgnoreCase(type)){
+                return category;
+            }
+        }
+        throw new InfrastructureException(ExceptionStatus.FILE_INFRASTRUCTURE_STORAGE_ERROR);
+    }
+
+}

--- a/src/main/java/org/certis/studyplatform/shared/type/ImageCategory.java
+++ b/src/main/java/org/certis/studyplatform/shared/type/ImageCategory.java
@@ -11,6 +11,8 @@ import org.certis.studyplatform.exception.InfrastructureException;
 @RequiredArgsConstructor
 public enum ImageCategory {
     BLOG("blog","blog-image"),
+    BOARD("board","board-image"),
+    STUDY("study","study-image"),
     PROJECT("project","project-image");
 
     private final String requestType; // 프론트에서 보내는 값
@@ -22,7 +24,7 @@ public enum ImageCategory {
                 return category;
             }
         }
-        throw new InfrastructureException(ExceptionStatus.FILE_INFRASTRUCTURE_STORAGE_ERROR);
+        throw new InfrastructureException(ExceptionStatus.FILE_INFRASTRUCTURE_STORAGE_ERROR,"적절하지 않은 분류의 이미지 입니다");
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -120,7 +120,7 @@ aws:
   s3:
     bucket-name: ${AWS_S3_BUCKET:test-bucket}
     image-bucket-name: ${AWS_S3_IMAGE_BUCKET:test-bucket}
-    region: ${AWS_DEFAULT_REGION:ap-northeast-2}
+    region: ${AWS_DEFAULT_REGION:ap-southeast-2}
     access-key-id: ${AWS_ACCESS_KEY_ID:}
     secret-access-key: ${AWS_SECRET_ACCESS_KEY:}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -119,6 +119,7 @@ spring:
 aws:
   s3:
     bucket-name: ${AWS_S3_BUCKET:test-bucket}
+    image-bucket-name: ${AWS_S3_IMAGE_BUCKET:test-bucket}
     region: ${AWS_DEFAULT_REGION:ap-northeast-2}
     access-key-id: ${AWS_ACCESS_KEY_ID:}
     secret-access-key: ${AWS_SECRET_ACCESS_KEY:}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #113 

## 📝작업 내용

> S3에 image를 저장하고 url을 반환하는 서비스 로직을 작성하였습니다.
S3에 접근하기 위해 기존 클린 아키텍처 구조에서 infra까지 내려가기 앞서 presentation과 application까지 계층이 내려가며 순수 domain로직이없어 infra계층은 application계층에 의존하도록 만들었습니다. 
port와 adaptor의 개념을 나름대로 해석하여 작성하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
